### PR TITLE
Libmonkey: fix build and add test for mimetype

### DIFF
--- a/configure
+++ b/configure
@@ -590,6 +590,7 @@ create_makefile2()
 
         if [ $malloc_jemalloc -eq 1 ]; then
                 extra="../deps/jemalloc/lib/libjemalloc.a"
+                extraso="-Wl,--whole-archive ../deps/jemalloc/lib/libjemalloc_pic.a -Wl,--no-whole-archive"
                 libs="$libs -lm"
         fi
 
@@ -625,12 +626,13 @@ lib: $SONAME
 	\$(CC_QUIET) \$(CFLAGS) \$(DEFS) \$(LDFLAGS) -o \$@ \$(OBJ) $mod_obj $extra \$(LIBS)
 
 $SONAME: \$(LIBOBJ)
-	\$(CC_QUIET) \$(CFLAGS) \$(LIBDEFS) \$(LDFLAGS) -Wl,-soname,$SONAME -shared -o \$@ \$(LIBOBJ) $mod_obj \$(LIBS)
+	\$(CC_QUIET) \$(CFLAGS) \$(LIBDEFS) \$(LDFLAGS) -Wl,-soname,$SONAME -shared -o \$@ $extraso \$(LIBOBJ) $mod_obj \$(LIBS)
+	ln -sf $SONAME libmonkey.so
 
 \$(LIBOBJ): \$(OBJ)
 
 clean:
-	rm -rf *.[od] $SONAME *.lo
+	rm -rf *.[od] $SONAME libmonkey.so *.lo
 	rm -rf ../bin/monkey
 
 distclean:
@@ -949,7 +951,7 @@ mandir="$aux/man"
 sysconfdir="$aux/conf"
 datadir="$aux/htdocs"
 logdir="$aux/logs"
-plugdir=""
+plugdir="$aux/plugins"
 platform="generic"
 
 # Generic default values for monkey.conf
@@ -1202,7 +1204,7 @@ fi
 if [ $malloc_libc -eq 1 ]; then
         DEFS="$DEFS -DMALLOC_LIBC"
 else
-        DEFS="$DEFS -DMALLOC_JEMALLOC"
+        DEFS="$DEFS -DMALLOC_JEMALLOC -DJEMALLOC_MANGLE"
 fi
 
 if [ $platform != "generic" ] && [ $platform != "android" ]; then

--- a/src/include/mk_list.h
+++ b/src/include/mk_list.h
@@ -77,6 +77,14 @@ static inline int mk_list_is_empty(struct mk_list *head)
     else return -1;
 }
 
+static inline int mk_list_size(struct mk_list *head)
+{
+    int ret = 0;
+    struct mk_list *it;
+    for (it = head->next; it != head; it = it->next, ret++);
+    return ret;
+}
+
 #define mk_list_foreach(curr, head) for( curr = (head)->next; curr != (head); curr = curr->next )
 #define mk_list_foreach_safe(curr, n, head) \
     for (curr = (head)->next, n = curr->next; curr != (head); curr = n, n = curr->next)

--- a/src/include/mk_mimetype.h
+++ b/src/include/mk_mimetype.h
@@ -48,6 +48,5 @@ int mk_mimetype_add(char *name, const char *type);
 void mk_mimetype_read_config(void);
 struct mimetype *mk_mimetype_find(mk_ptr_t * filename);
 struct mimetype *mk_mimetype_lookup(char *name);
-void mk_mimearr_sort();
 
 #endif

--- a/src/mk_mimetype.c
+++ b/src/mk_mimetype.c
@@ -38,7 +38,6 @@
 #include "mk_macros.h"
 
 struct mimetype *mimetype_default;
-struct mimetype *mimearr = NULL; /* array of the mime types */
 
 /* Match mime type for requested resource */
 inline struct mimetype *mk_mimetype_lookup(char *name)

--- a/tests/lib/mimetype.c
+++ b/tests/lib/mimetype.c
@@ -1,0 +1,34 @@
+#include <libmonkey.h>
+
+int main() {
+
+	mklib_ctx c1 = mklib_init(NULL, 0, 0, NULL);
+	if (!c1) return 1;
+
+    char name1[] = "name1", name2[] = "name2";
+    int size = 0, i = 0;
+
+	if (!mklib_start(c1))
+        return 1;
+
+    struct mklib_mime **mts = mklib_mimetype_list(c1);
+
+    while(mts[i++])
+        size++;
+
+    mklib_mimetype_add(c1, name1, "1");
+    mklib_mimetype_add(c1, name2, "2");
+
+    mts = mklib_mimetype_list(c1);
+    i = 0;
+    while (mts[i++])
+        size--;
+
+    if (size != -2)
+        return 1;
+
+	if (!mklib_stop(c1))
+        return 1;
+
+	return 0;
+}

--- a/tests/lib/run-tests.sh
+++ b/tests/lib/run-tests.sh
@@ -71,12 +71,12 @@ echo
 
 total=$((fail + success))
 percentage=$(awk "BEGIN{print $success/$total * 100}")
-percentage=$(printf '%.2f' $percentage)
+fpercentage=$(printf '%.2f' $percentage)
 
 num=${percentage//.*/}
 
 [ $fail -eq 0 ] && echo "$GREEN	All tests passed!"
-[ $fail -ne 0 -a $num -ge 60 ] && echo "$YELLOW	$percentage% passed, $fail/$total fails"
-[ $num -lt 60 ] && echo "$RED	$percentage% passed, $fail/$total fails"
+[ $fail -ne 0 -a $percentage -ge 60 ] && echo "$YELLOW	$fpercentage% passed, $fail/$total fails"
+[ $percentage -lt 60 ] && echo "$RED	$fpercentage% passed, $fail/$total fails"
 
 echo $NORMAL


### PR DESCRIPTION
I fixed the linking with Jemalloc library (issue #102). The libmonkey shared object is linked statically with Jemalloc, so now all symbols from libjemalloc.a are defined in libmonkey.so, effectively increasing its size.

I fixed the proper use of mimetype red-black trees (issue #101), in order to make the library work. I also added a test for the mklib_mimetype_list function, to be sure that the fix actually works. I made other minor modifications to make possible to use the library test suite from tests/lib.

After doing the modifications, I tested with various options to configure (--enable-shared, --prefix=/path, --malloc-libc, --plugdir=/path). After make && make install, the results were as expected.
