### PR TITLE
Monkey configuration: add program options for configuration paths

### DIFF
--- a/src/include/mk_config.h
+++ b/src/include/mk_config.h
@@ -32,9 +32,13 @@
 #define O_NOATIME       01000000
 #endif
 
-#define M_DEFAULT_CONFIG_FILE	"monkey.conf"
-#define MK_DEFAULT_LISTEN_ADDR  "0.0.0.0"
-#define MK_WORKERS_DEFAULT 1
+#define M_DEFAULT_CONFIG_FILE               "monkey.conf"
+#define MK_DEFAULT_MIMES_CONF_FILE          "monkey.mime"
+#define MK_DEFAULT_PLUGIN_LOAD_CONF_FILE    "plugins.load"
+#define MK_DEFAULT_SITES_CONF_DIR           "sites/"
+#define MK_DEFAULT_PLUGINS_CONF_DIR         "plugins/"
+#define MK_DEFAULT_LISTEN_ADDR              "0.0.0.0"
+#define MK_WORKERS_DEFAULT                  1
 
 #define VALUE_ON "on"
 #define VALUE_OFF "off"
@@ -91,7 +95,11 @@ struct server_config
     char *user_dir;
     char *pid_file_path;        /* pid of server */
     char *path_config;
-    char *server_config;
+    char *server_conf_file;
+    char *mimes_conf_file;
+    char *plugin_load_conf_file;
+    char *sites_conf_dir;
+    char *plugins_conf_dir;
     char **request_headers_allowed;
 
     int serverport;             /* port */

--- a/src/include/mk_plugin.h
+++ b/src/include/mk_plugin.h
@@ -36,8 +36,6 @@
 #include "mk_list.h"
 #include "mk_info.h"
 
-#define MK_PLUGIN_LOAD "plugins.load"
-
 #define MK_PLUGIN_ERROR -1      /* plugin execution error */
 #define MK_PLUGIN_
 

--- a/src/mk_config.c
+++ b/src/mk_config.c
@@ -386,7 +386,7 @@ static void mk_config_read_files(char *path_conf, char *file_conf)
 
     cnf = mk_config_create(tmp);
     if (!cnf) {
-        mk_err("Cannot read '%s'", config->server_config);
+        mk_err("Cannot read '%s'", config->server_conf_file);
         exit(EXIT_FAILURE);
     }
     section = mk_config_section_get(cnf, "SERVER");
@@ -542,7 +542,7 @@ void mk_config_start_configure(void)
     unsigned long len;
 
     mk_config_set_init_values();
-    mk_config_read_files(config->path_config, config->server_config);
+    mk_config_read_files(config->path_config, config->server_conf_file);
 
     /* Load mimes */
     mk_mimetype_read_config();

--- a/src/mk_mimetype.c
+++ b/src/mk_mimetype.c
@@ -36,6 +36,7 @@
 #include "mk_request.h"
 #include "mk_list.h"
 #include "mk_macros.h"
+#include "mk_file.h"
 
 struct mimetype *mimetype_default;
 
@@ -119,13 +120,19 @@ void mk_mimetype_read_config()
     struct mk_config_section *section;
     struct mk_config_entry *entry;
     struct mk_list *head;
+    struct file_info f_info;
+    int ret;
 
     /* Initialize the heads */
     mk_list_init(&mimetype_list);
     mimetype_rb_head = RB_ROOT;
 
     /* Read mime types configuration file */
-    snprintf(path, MK_MAX_PATH, "%s/monkey.mime", config->serverconf);
+    snprintf(path, MK_MAX_PATH, "%s/%s", config->serverconf, config->mimes_conf_file);
+    ret = mk_file_get_info(path, &f_info);
+    if (ret == -1 || f_info.is_file == MK_FALSE)
+        snprintf(path, MK_MAX_PATH, "%s", config->mimes_conf_file);
+
     cnf = mk_config_create(path);
     if (!cnf) {
         exit(EXIT_FAILURE);


### PR DESCRIPTION
This patch solves the issue #36.

4 additional program arguments were added for specifying different
configuration files and directories:

-m, --mimes-conf-file # path to monkey.mime
-P, --plugins-conf-dir # path to plugins configuration directory
-l, --plugin-load-conf-file # path to plugins.load file
-S, --sites-conf-dir # path to sites directory

Each option has a default value.

Monkey will try to interpret the options by prepending their values
to default configuration directory. If the obtained path does not
exist, the options will be treated as absolute paths.

I tested using ./configure --prefix=path --plugdir=--path2 and
default build. I was able to load different configuration files
from custom locations with custom names, overriding the default
names which were hardcoded in Monkey.

The patch also contains an unrelated fix to:

bin/monkey --confdir # was not working, while provided by --help

Signed-off-by: Vladimir Cernov gg.kaspersky@gmail.com
