### PR TITLE
Scheduler-Plugin: Moving and renaming function mk_sched_worker_info()

### DIFF
--- a/src/include/mk_plugin.h
+++ b/src/include/mk_plugin.h
@@ -371,4 +371,6 @@ int mk_plugin_header_get(struct session_request *sr,
                          mk_ptr_t query,
                          mk_ptr_t *result);
 
+struct sched_list_node *mk_plugin_sched_get_thread_conf();
+
 #endif

--- a/src/include/mk_scheduler.h
+++ b/src/include/mk_scheduler.h
@@ -135,8 +135,6 @@ struct sched_connection *mk_sched_get_connection(struct sched_list_node
                                                      *sched, int remote_fd);
 int mk_sched_update_conn_status(struct sched_list_node *sched, int remote_fd,
                                 int status);
-struct sched_list_node *mk_sched_worker_info();
-
 int mk_sched_sync_counters();
 
 #endif

--- a/src/mk_plugin.c
+++ b/src/mk_plugin.c
@@ -406,7 +406,7 @@ void mk_plugin_init()
     /* Scheduler and Event callbacks */
     api->sched_get_connection = mk_sched_get_connection;
     api->sched_remove_client  = mk_plugin_sched_remove_client;
-    api->sched_worker_info    = mk_sched_worker_info;
+    api->sched_worker_info    = mk_plugin_sched_get_thread_conf;
 
     api->event_add = mk_plugin_event_add;
     api->event_del = mk_plugin_event_del;
@@ -1270,4 +1270,9 @@ int mk_plugin_header_add(struct session_request *sr, char *row, int len)
     mk_iov_add_entry(sr->headers._extra_rows, row, len,
                      mk_iov_crlf, MK_IOV_NOT_FREE_BUF);
     return 0;
+}
+
+struct sched_list_node *mk_plugin_sched_get_thread_conf()
+{
+    return pthread_getspecific(worker_sched_node);
 }

--- a/src/mk_scheduler.c
+++ b/src/mk_scheduler.c
@@ -617,8 +617,3 @@ int mk_sched_update_conn_status(struct sched_list_node *sched,
 
     return 0;
 }
-
-struct sched_list_node *mk_sched_worker_info()
-{
-    return pthread_getspecific(worker_sched_node);
-}


### PR DESCRIPTION
The patch contains changes for moving function 'struct sched_list_node *mk_sched_worker_info()' from src/mk_scheduler.c to src/mk_plugin.c and renames it as 'struct sched_list_node *mk_plugin_sched_get_thread_conf()', since it was found that the function is used by plugin api.
