### PR TITLE
Systemd: add unit file monkey.service

### DIFF
--- a/configure
+++ b/configure
@@ -203,6 +203,8 @@ main()
 	echo "+ Creating bin/banana script"
 	create_banana_script bindir logdir default_port
 
+	create_monkey_systemd_script bindir logdir default_port systemddir
+
 	echo -e "+ Creating Makefile"
 	if [ "$dir" = 0 ]; then
 		create_makefile1 bindir malloc_jemalloc
@@ -264,6 +266,8 @@ main()
 	if [ "$plugdir" != "" ]; then
 		echo -e "Plugdir\t\t= $plugdir"
 	fi
+
+	echo -e "Systemddir\t= $systemddir"
 
 	echo
 	echo "--"
@@ -488,6 +492,12 @@ create_makefile1_install()
 		incinstall="	install -m 644 src/include/public/libmonkey.h \$(INCDIR)"
 	fi
 
+	ins_systemd=""
+	if [ $systemddir ]; then
+		ins_systemd="	install -d \$(SYSTEMDDIR)
+	install -m 644 monkey.service \$(SYSTEMDDIR)"
+	fi
+
 	cat > Makefile <<EOF
 # Monkey HTTP Daemon: Makefile
 # ============================
@@ -500,6 +510,7 @@ MANDIR=\$(DESTDIR)${mandir}
 SYSCONFDIR=\$(DESTDIR)${sysconfdir}
 DATADIR=\$(DESTDIR)${datadir}
 LOGDIR=\$(DESTDIR)${logdir}
+SYSTEMDDIR=$systemddir
 PLUGINDIR=\$(DESTDIR)${plugdir}
 VERSION=$VERSION
 
@@ -539,6 +550,7 @@ install:
 	install -m 755 bin/* \$(BINDIR)
 	install -m 644 ./conf/*.* \$(SYSCONFDIR)
 	install -m 644 src/include/*.h \$(INCDIR)
+$ins_systemd
 $plgconf
 $plglist
 	install -m 644 ./conf/sites/* \${SYSCONFDIR}/sites
@@ -822,6 +834,28 @@ logdir=$logdir
 EOF
 }
 
+create_monkey_systemd_script()
+{
+	if [ $systemddir ]; then
+        echo "+ Creating systemd.service unit file"
+		cat > monkey.service << EOF
+[Unit]
+Description=Monkey HTTP Server
+Requires=network.target
+After=network.target
+
+[Service]
+Type=fork
+ExecStart=$bindir/monkey -D
+PIDFile=$logdir/monkey.pid.$default_port
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+EOF
+	fi
+}
+
 create_banana_script()
 {
 	cat > bin/banana << EOF
@@ -952,6 +986,7 @@ sysconfdir="$aux/conf"
 datadir="$aux/htdocs"
 logdir="$aux/logs"
 plugdir="$aux/plugins"
+systemddir=""
 platform="generic"
 
 # Generic default values for monkey.conf
@@ -1063,6 +1098,13 @@ for arg in $*; do
 		--default-user*)
 			default_user=$optarg
 			;;
+		--systemddir*)
+			if [ $optarg ] ; then
+				systemddir=$optarg
+			else
+				systemddir=/lib/systemd/system
+			fi
+			;;
 		--version*)
 			echo -e $bldgrn"Monkey HTTP Daemon v$VERSION" $txtrst
 			echo "Copyright 2001-2013 - Monkey Development Team"
@@ -1104,6 +1146,7 @@ for arg in $*; do
 			echo "  --mandir=MANDIR         Manpages - documentation"
 			echo "  --logdir=LOGDIR         Log files"
 			echo "  --plugdir=PLUGDIR       Plugins directory path"
+			echo "  --systemddir[=DIR]      Systemd directory path"
 			echo "  --enable-plugins=a,b    Enable the listed plugins"
 			echo "  --disable-plugins=a,b   Disable the listed plugins"
 			echo "  --only-accept           Use only accept(2)"


### PR DESCRIPTION
This patch adds a unit file for systemd init system, as described in issue #39.
The installation of the unit file is triggered by the "--systemddir" passed to configure script, in the following way:
$ ./configure                           # no systemd unit file deployed
$ ./configure --systemddir              # Unit file systemd.service is created with default installation path "/lib/systemd/system"
$ ./configure --systemddir=CUSTOM_PATH  # Unit file systemd.service is created with installation path "CUSTOM_PATH"

The unit file is deployed is deployed using "make install" command, so you should also specify "--prefix" option for configure.

I tested the patch on archlinux and fedora (systemd init system) deploying the unit file in different system paths. The following commands were successful:
$ service monkey start
$ systemctl start monkey.service

I also tested on ubuntu (upstart init system), ensuring nothing is broken.

Signed-off-by: Vladimir Cernov gg.kaspersky@gmail.com
