### PR TITLE
mk_socket: Added a variable that accepts return value for read() in tcp_autocorking function

### DIFF
--- a/src/mk_socket.c
+++ b/src/mk_socket.c
@@ -248,6 +248,7 @@ int mk_socket_ip_str(int socket_fd, char **buf, int size, unsigned long *len)
 int mk_socket_tcp_autocorking()
 {
     int fd;
+    int read_ret;
     int ret = MK_FALSE;
     char buf[2];
     struct stat st;
@@ -262,7 +263,11 @@ int mk_socket_tcp_autocorking()
         return MK_FALSE;
     }
 
-    read(fd, buf, 1);
+    read_ret = read(fd, buf, 1);
+    if (read_ret == -1) {
+        return MK_FALSE;
+    }
+
     close(fd);
     buf[1] = '\0';
 


### PR DESCRIPTION
Added a variable to accept the return value of read() function in mk_socket_tcp_autocorking ().
Motivation: It removes the following warning that arises during 'make'

---------------  WARNING  --------------------
mk_socket.c: In function ‘mk_socket_tcp_autocorking’:
mk_socket.c:265:9: warning: ignoring return value of ‘read’, declared with attribute warn_unused_result [-Wunused-result]
---------------  WARNING  --------------------
