### PR TITLE
mk_signal: Removed unused variable 'old' in function mk_signal_thread_sigpipe_safe()

### DIFF
--- a/src/mk_signals.c
+++ b/src/mk_signals.c
@@ -68,7 +68,7 @@ static void mk_signal_exit()
 
 void mk_signal_thread_sigpipe_safe()
 {
-    sigset_t set, old;
+    sigset_t set;
 
     sigemptyset(&set);
     sigaddset(&set, SIGPIPE);


### PR DESCRIPTION
Removed the sigset_t old from line 71 from function - void mk_signal_thread_sigpipe_safe(). 
It removes the following warning arising during 'make'.
------------------  WARNING  ---------------------
mk_signals.c: In function ‘mk_signal_thread_sigpipe_safe’:
mk_signals.c:71:19: warning: unused variable ‘old’ [-Wunused-variable]
------------------  WARNING  ---------------------
