### PR TITLE
Scheduler: Fix warning for implicit declaration

### DIFF
--- a/src/include/mk_scheduler.h
+++ b/src/include/mk_scheduler.h
@@ -155,5 +155,6 @@ struct sched_connection *mk_sched_get_connection(struct sched_list_node
 int mk_sched_update_conn_status(struct sched_list_node *sched, int remote_fd,
                                 int status);
 int mk_sched_sync_counters();
+int mk_sched_check_capacity(struct sched_list_node *sched);
 
 #endif


### PR DESCRIPTION
Add declaration of mk_sched_check_capacity in mk_scheduler.h

Signed-off-by: Vladimir Cernov gg.kaspersky@gmail.com
