### PR TITLE
Plugin: add export to buffer_size function.

### DIFF
--- a/include/monkey/mk_api.h
+++ b/include/monkey/mk_api.h
@@ -79,6 +79,7 @@ int MK_EXPORT _mkp_network_io_create_socket(int domain, int type, int protocol);
 int MK_EXPORT _mkp_network_io_bind(int socket_fd, const struct sockaddr *addr,
                                    socklen_t addrlen, int backlog);
 int MK_EXPORT _mkp_network_io_server(int port, char *listen_addr, int reuse_port);
+int MK_EXPORT _mkp_network_io_buffer_size();
 int MK_EXPORT _mkp_event_read(int sockfd);
 int MK_EXPORT _mkp_event_write(int sockfd);
 int MK_EXPORT _mkp_event_error(int sockfd);


### PR DESCRIPTION
 This patch fixes a problem where `mk_plugin_load_symbol` function returns null pointer
 for "_mkp_network_io_buffer_size" in Ubuntu 12.04 with gcc 4.6.3.
