### PR TITLE
Adds support for custom HTTP headers in replies

### DIFF
--- a/include/monkey/mk_header.h
+++ b/include/monkey/mk_header.h
@@ -86,7 +86,39 @@ struct header_status_response {
     char *response;
 };
 
+/* Header field names */
+#define MK_HF_DATE "Date"
+#define MK_HF_LOCATION "Location"
+#define MK_HF_CONTENT_TYPE "Content-Type"
+#define MK_HF_ACCEPT_RANGES "Accept-Ranges"
+#define MK_HF_ALLOW "Allow"
+#define MK_HF_CONNECTION "Connection"
+#define MK_HF_CONTENT_LENGTH "Content-Length"
+#define MK_HF_CONTENT_ENCODING "Content-Encoding"
+#define MK_HF_TRANSFER_ENCODING "Transfer-Encoding"
+#define MK_HF_LAST_MODIFIED "Last-Modified"
+
+/* Short header values */
+#define MK_HEADER_SHORT_DATE MK_HF_DATE ": "
+#define MK_HEADER_SHORT_LOCATION MK_HF_LOCATION ": "
+#define MK_HEADER_SHORT_CT MK_HF_CONTENT_TYPE ": "
+
+/* Accept ranges */
+#define MK_HEADER_ACCEPT_RANGES MK_HF_ACCEPT_RANGES ": bytes" MK_CRLF
+
+/* Allowed methods */
+#define MK_HEADER_ALLOWED_METHODS MK_HF_ALLOW ": "
+
+#define MK_HEADER_CONN_KA MK_HF_CONNECTION ": Keep-Alive" MK_CRLF
+#define MK_HEADER_CONN_CLOSE MK_HF_CONNECTION ": Close" MK_CRLF
+#define MK_HEADER_CONTENT_LENGTH MK_HF_CONTENT_LENGTH ": "
+#define MK_HEADER_CONTENT_ENCODING MK_HF_CONTENT_ENCODING ": "
+
+/* Transfer Encoding */
 #define MK_HEADER_TE_TYPE_CHUNKED 0
+#define MK_HEADER_TE_CHUNKED MK_HF_TRANSFER_ENCODING ": Chunked" MK_CRLF
+
+#define MK_HEADER_LAST_MODIFIED MK_HF_LAST_MODIFIED ": "
 
 extern const mk_ptr_t mk_header_short_date;
 extern const mk_ptr_t mk_header_short_location;

--- a/include/monkey/mk_vhost.h
+++ b/include/monkey/mk_vhost.h
@@ -32,6 +32,14 @@ struct error_page {
     struct mk_list _head;
 };
 
+/* Custom header */
+struct custom_header {
+    char *header;
+    char *value;
+    char *response_header;
+    struct mk_list _head;
+};
+
 struct host
 {
     char *file;                   /* configuration file */
@@ -45,6 +53,9 @@ struct host
 
     /* custom error pages */
     struct mk_list error_pages;
+
+    /* custom headers */
+    struct mk_list custom_headers;
 
     /* link node */
     struct mk_list _head;

--- a/include/monkey/mk_vhost.h
+++ b/include/monkey/mk_vhost.h
@@ -24,6 +24,11 @@
 #ifndef MK_VHOST_H
 #define MK_VHOST_H
 
+struct denied_response_header {
+    char *header;
+    int  length;
+};
+
 /* Custom error page */
 struct error_page {
     short int status;

--- a/src/mk_header.c
+++ b/src/mk_header.c
@@ -144,6 +144,8 @@ int mk_header_send(int fd, struct mk_http_session *cs,
     char *buffer = 0;
     mk_ptr_t response;
     struct response_headers *sh;
+    struct mk_list *head;
+    struct custom_header *entry;
     struct mk_iov *iov;
 
     sh = &sr->headers;
@@ -337,6 +339,15 @@ int mk_header_send(int fd, struct mk_http_session *cs,
                             (sh->real_length - 1), sh->real_length);
             mk_iov_add(iov, buffer, len, MK_IOV_FREE_BUF);
         }
+    }
+
+    /* Custom headers */
+    mk_list_foreach(head, &sr->host_conf->custom_headers) {
+        entry = mk_list_entry(head, struct custom_header, _head);
+
+        mk_iov_add_entry(iov, entry->response_header,
+                         strlen(entry->response_header),
+                         mk_iov_crlf, MK_IOV_NOT_FREE_BUF);
     }
 
     mk_server_cork_flag(fd, TCP_CORK_ON);


### PR DESCRIPTION
The **Virtual Hosts** now support custom HTTP headers.

> [CUSTOM_HEADERS]
> X-Frame-Options deny
> X-XSS-Protection 1; mode=block
> X-Content-Type-Options nosniff
> Content-Security-Policy default-src 'self'