### PR TITLE
Config: Add printf info on which plugins are loaded on startup

### DIFF
--- a/src/mk_config.c
+++ b/src/mk_config.c
@@ -434,6 +434,22 @@ void mk_details(void)
     }
 #endif
 
+    struct plugin *node;
+    struct mk_list *head;
+    printf(MK_BANNER_ENTRY "Loaded plugins: ");
+    int started = 0;
+    mk_list_foreach(head, config->plugins) {
+        node = mk_list_entry(head, struct plugin, _head);
+        if (started == 0)
+        {
+            started = -1;
+        }
+        else {
+            printf(", ");
+        }
+        printf(node->shortname);
+    }
+
     fflush(stdout);
 }
 


### PR DESCRIPTION
The problem is that it is very hard to reason about what monkey has currently *really* loaded. A user would have to debug into monkey to find out whether plugin X was really loaded or not. This change shows at least which plugins are loaded, future changes could include from which plugins.load file they were loaded.

Signed-off-by: Traktor Toni trustthesky@email.com