### PR TITLE
Issue 170 implemented : Syslog functional and optional

### DIFF
--- a/configure
+++ b/configure
@@ -991,6 +991,12 @@ create_info()
 #define PYTHONVERSION python$PYTHONVERSION
 
 EOF
+	if [ "$syslog_enable" = "1" ]
+	then
+		str='#define SYSLOG\n'
+	fi
+
+	echo -e $str >> $base_path/$INCDIR/mk_info.h
 
 	sed -i $OS_SED -e "s@#define MONKEY__.*@#define MONKEY__            $__MONKEY__@" \
 	    -e "s@#define MONKEY_MINOR__.*@#define MONKEY_MINOR__      $__MONKEY_MINOR__@" \
@@ -1324,6 +1330,9 @@ for arg in $*; do
 		--static-plugins*)
 			static_plugins=$optarg
 			;;
+		--enable-syslog*)
+			syslog_enable=1
+			;;
 		--only-accept)
 			only_accept=1
 			;;
@@ -1410,6 +1419,7 @@ for arg in $*; do
                         echo "  --malloc-libc           Use system default memory allocator (default is jemalloc)"
 			echo "  --platform=PLATFORM     Target platform: 'generic' or 'android' (default: generic)"
 			echo "  --pthread-tls           Use Posix thread keys instead of compiler TLS"
+			echo "  --enable-syslog         Force logger to utilize Syslog for logging"
 			echo
 			echo -e $bldwht"Shared library options:" $txtrst
 			echo "  --enable-shared         Build Monkey as a shared library in addition to a stand-alone server"

--- a/deps/jemalloc/jemalloc.config
+++ b/deps/jemalloc/jemalloc.config
@@ -1,0 +1,145 @@
+checking for xsltproc... /home/pfrcks/anaconda/bin/xsltproc
+checking for gcc... gcc
+checking whether the C compiler works... yes
+checking for C compiler default output file name... a.out
+checking for suffix of executables... 
+checking whether we are cross compiling... no
+checking for suffix of object files... o
+checking whether we are using the GNU C compiler... yes
+checking whether gcc accepts -g... yes
+checking for gcc option to accept ISO C89... none needed
+checking how to run the C preprocessor... gcc -E
+checking for grep that handles long lines and -e... /bin/grep
+checking for egrep... /bin/grep -E
+checking for ANSI C header files... yes
+checking for sys/types.h... yes
+checking for sys/stat.h... yes
+checking for stdlib.h... yes
+checking for string.h... yes
+checking for memory.h... yes
+checking for strings.h... yes
+checking for inttypes.h... yes
+checking for stdint.h... yes
+checking for unistd.h... yes
+checking whether byte ordering is bigendian... no
+checking size of void *... 8
+checking size of int... 4
+checking size of long... 8
+checking size of intmax_t... 8
+checking build system type... x86_64-unknown-linux-gnu
+checking host system type... x86_64-unknown-linux-gnu
+checking whether pause instruction is compilable... yes
+checking whether SSE2 intrinsics is compilable... yes
+checking for ar... ar
+checking whether __attribute__ syntax is compilable... yes
+checking whether compiler supports -fvisibility=hidden... yes
+checking whether compiler supports -Werror... yes
+checking whether tls_model attribute is compilable... no
+checking for a BSD-compatible install... /usr/bin/install -c
+checking for ranlib... ranlib
+checking for ld... /usr/bin/ld
+checking for autoconf... /usr/bin/autoconf
+checking for memalign... yes
+checking for valloc... yes
+checking configured backtracing method... N/A
+checking for sbrk... yes
+checking whether utrace(2) is compilable... no
+checking whether valgrind is compilable... no
+checking STATIC_PAGE_SHIFT... 12
+cat: VERSION: No such file or directory
+checking pthread.h usability... yes
+checking pthread.h presence... yes
+checking for pthread.h... yes
+checking for pthread_create in -lpthread... yes
+checking for _malloc_thread_cleanup... no
+checking for _pthread_mutex_init_calloc_cb... no
+checking for TLS... yes
+checking whether a program using ffsl is compilable... yes
+checking whether atomic(9) is compilable... no
+checking whether Darwin OSAtomic*() is compilable... no
+checking whether to force 32-bit __sync_{add,sub}_and_fetch()... no
+checking whether to force 64-bit __sync_{add,sub}_and_fetch()... no
+checking whether Darwin OSSpin*() is compilable... no
+checking for stdbool.h that conforms to C99... yes
+checking for _Bool... yes
+configure: creating ./config.status
+config.status: creating Makefile
+config.status: creating doc/html.xsl
+config.status: creating doc/manpages.xsl
+config.status: creating doc/jemalloc.xml
+config.status: creating include/jemalloc/jemalloc_macros.h
+config.status: creating include/jemalloc/jemalloc_protos.h
+config.status: creating include/jemalloc/internal/jemalloc_internal.h
+config.status: creating test/test.sh
+config.status: creating test/include/test/jemalloc_test.h
+config.status: creating config.stamp
+config.status: creating bin/jemalloc.sh
+config.status: creating include/jemalloc/jemalloc_defs.h
+config.status: include/jemalloc/jemalloc_defs.h is unchanged
+config.status: creating include/jemalloc/internal/jemalloc_internal_defs.h
+config.status: include/jemalloc/internal/jemalloc_internal_defs.h is unchanged
+config.status: creating test/include/test/jemalloc_test_defs.h
+config.status: test/include/test/jemalloc_test_defs.h is unchanged
+config.status: executing include/jemalloc/internal/private_namespace.h commands
+config.status: executing include/jemalloc/internal/private_unnamespace.h commands
+config.status: executing include/jemalloc/internal/public_symbols.txt commands
+config.status: executing include/jemalloc/internal/public_namespace.h commands
+config.status: executing include/jemalloc/internal/public_unnamespace.h commands
+config.status: executing include/jemalloc/internal/size_classes.h commands
+config.status: executing include/jemalloc/jemalloc_protos_jet.h commands
+config.status: executing include/jemalloc/jemalloc_rename.h commands
+config.status: executing include/jemalloc/jemalloc_mangle.h commands
+config.status: executing include/jemalloc/jemalloc_mangle_jet.h commands
+config.status: executing include/jemalloc/jemalloc.h commands
+===============================================================================
+jemalloc version   : 
+library revision   : 1
+
+CC                 : gcc
+CPPFLAGS           :  -D_GNU_SOURCE -D_REENTRANT
+CFLAGS             : -std=gnu99 -Wall -pipe -g3 -O3 -funroll-loops  -fvisibility=hidden
+LDFLAGS            : 
+EXTRA_LDFLAGS      : 
+LIBS               :  -lpthread
+RPATH_EXTRA        : 
+
+XSLTPROC           : /home/pfrcks/anaconda/bin/xsltproc
+XSLROOT            : /usr/share/xml/docbook/stylesheet/docbook-xsl
+
+PREFIX             : /usr/local
+BINDIR             : /usr/local/bin
+INCLUDEDIR         : /usr/local/include
+LIBDIR             : /usr/local/lib
+DATADIR            : /usr/local/share
+MANDIR             : /usr/local/share/man
+
+srcroot            : 
+abs_srcroot        : /home/pfrcks/amol/monkey/deps/jemalloc/
+objroot            : 
+abs_objroot        : /home/pfrcks/amol/monkey/deps/jemalloc/
+
+JEMALLOC_PREFIX    : je_
+JEMALLOC_PRIVATE_NAMESPACE
+                   : je_
+install_suffix     : 
+autogen            : 0
+experimental       : 1
+cc-silence         : 1
+debug              : 0
+code-coverage      : 0
+stats              : 1
+prof               : 0
+prof-libunwind     : 0
+prof-libgcc        : 0
+prof-gcc           : 0
+tcache             : 1
+fill               : 1
+utrace             : 0
+valgrind           : 0
+xmalloc            : 0
+mremap             : 0
+munmap             : 0
+dss                : 0
+lazy_lock          : 0
+tls                : 1
+===============================================================================

--- a/include/monkey/mk_static_plugins.h
+++ b/include/monkey/mk_static_plugins.h
@@ -1,0 +1,12 @@
+#include <monkey/mk_plugin.h>
+
+struct mk_plugin mk_plugin_liana;
+
+void mk_static_plugins()
+{
+    struct mk_plugin *p;
+
+    p = &mk_plugin_liana;
+    mk_list_add(&p->_head, mk_config->plugins);
+
+}

--- a/plugins/Make.static
+++ b/plugins/Make.static
@@ -1,0 +1,2 @@
+all:
+	$(MAKE) -C liana/ monkey-liana.a


### PR DESCRIPTION
Syslog has been implemented and can be made to work using the --enable-syslog option during configuration.
This option defines Syslog in mk_info.h file which in turn is read by logger.c
Now based on whether the option is set or not, logger.c decided whether to log to syslog or to the log files()

At present logger facility on master is broken so Syslog will not work even though it has been implemented. As soon as logger is fixed it will start working too.
Syslog utilizes syslog.h header file and logs to /var/log/syslog