### PR TITLE
Change in include directories and call to channel_write

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -286,6 +286,7 @@ configure_file(
 # General Headers
 include_directories(include/)
 include_directories(src/)
+include_directories(src/mk_core/include)
 
 add_subdirectory(plugins/)
 

--- a/plugins/auth/auth.c
+++ b/plugins/auth/auth.c
@@ -139,6 +139,7 @@ int mk_auth_stage30(struct mk_plugin *plugin,
                     struct mk_http_request *sr)
 {
     int val;
+    size_t count;
     short int is_restricted = MK_FALSE;
     struct mk_list *vh_head;
     struct mk_list *loc_head;
@@ -210,7 +211,7 @@ int mk_auth_stage30(struct mk_plugin *plugin,
                        loc_entry->auth_http_header.data,
                        loc_entry->auth_http_header.len);
     mk_api->header_prepare(cs, sr);
-    mk_api->channel_write(&cs->channel);
+    mk_api->channel_write(&cs->channel,&count);
 
     return MK_PLUGIN_RET_END;
 }

--- a/plugins/dirlisting/dirlisting.c
+++ b/plugins/dirlisting/dirlisting.c
@@ -699,6 +699,7 @@ int mk_dirhtml_init(struct mk_http_session *cs, struct mk_http_request *sr)
 {
     DIR *dir;
     unsigned int i = 0;
+    size_t count;
     char *title = 0;
     struct mk_f_list *file_list, *entry;
     struct dirhtml_value *values_global = 0;
@@ -784,7 +785,7 @@ int mk_dirhtml_init(struct mk_http_session *cs, struct mk_http_request *sr)
      * Dispatch, once we get a callback on mk_dirhtml_cb_finish, we
      * continue appending data to the channel
      */
-    mk_api->channel_write(&cs->channel);
+    mk_api->channel_write(&cs->channel, &count);
 
     return 0;
 }


### PR DESCRIPTION
One extra include directory added in CMakelist.txt at the top directory.
The count variable that stores the number of bytes in channel_write function wasn't passed to it when calling it in two files. Hence the build errors. 
Applying this patch, monkey builds and runs correctly. 