### PR TITLE
Patch allows monkey to run on FreeBSD and Linux using Kqueue

### DIFF
--- a/include/monkey/mk_file.h
+++ b/include/monkey/mk_file.h
@@ -24,6 +24,8 @@
 #define MK_FILE_READ   2
 #define MK_FILE_EXEC   4
 
+#include <time.h>
+
 struct file_info
 {
     off_t size;

--- a/mk_core/mk_event_kqueue.c
+++ b/mk_core/mk_event_kqueue.c
@@ -79,12 +79,12 @@ static inline int _mk_event_add(struct mk_event_ctx *ctx, int fd,
 
     /* Read flag */
     if ((event->mask ^ MK_EVENT_READ) && (events & MK_EVENT_READ)) {
-        EV_SET(&ke, fd, EVFILT_READ, EV_ADD, 0, 0, event);
+        EV_SET(&ke, fd, EVFILT_READ, EV_ADD, 0, 0, data);
         set = MK_TRUE;
         //printf("[ADD] fd=%i READ\n", fd);
     }
     else if ((event->mask & MK_EVENT_READ) && (events ^ MK_EVENT_READ)) {
-        EV_SET(&ke, fd, EVFILT_READ, EV_DELETE, 0, 0, event);
+        EV_SET(&ke, fd, EVFILT_READ, EV_DELETE, 0, 0, data);
         set = MK_TRUE;
         //printf("[DEL] fd=%i READ\n", fd);
     }
@@ -100,12 +100,12 @@ static inline int _mk_event_add(struct mk_event_ctx *ctx, int fd,
     /* Write flag */
     set = MK_FALSE;
     if ((event->mask ^ MK_EVENT_WRITE) && (events & MK_EVENT_WRITE)) {
-        EV_SET(&ke, fd, EVFILT_WRITE, EV_ADD, 0, 0, event);
+        EV_SET(&ke, fd, EVFILT_WRITE, EV_ADD, 0, 0, data);
         set = MK_TRUE;
         //printf("[ADD] fd=%i WRITE\n", fd);
     }
     else if ((event->mask & MK_EVENT_WRITE) && (events ^ MK_EVENT_WRITE)) {
-        EV_SET(&ke, fd, EVFILT_WRITE, EV_DELETE, 0, 0, event);
+        EV_SET(&ke, fd, EVFILT_WRITE, EV_DELETE, 0, 0, data);
         set = MK_TRUE;
         //printf("[DEL] fd=%i WRITE\n", fd);
     }
@@ -117,6 +117,7 @@ static inline int _mk_event_add(struct mk_event_ctx *ctx, int fd,
             return ret;
         }
     }
+    event->mask = events;
 
     return 0;
 }

--- a/plugins/liana/liana.c
+++ b/plugins/liana/liana.c
@@ -86,11 +86,14 @@ int mk_liana_send_file(int socket_fd, int file_fd, off_t *file_offset,
                      socket_fd, strerror(errno));
     }
     return ret;
-#elif defined (__APPLE__)
+#elif defined (__APPLE__) || defined(__FreeBSD__)
     off_t offset = *file_offset;
     off_t len = (off_t) file_count;
-
+#if defined (__APPLE__)
     ret = sendfile(file_fd, socket_fd, offset, &len, NULL, 0);
+#else
+    ret = sendfile(file_fd, socket_fd, offset, &len, NULL, 0, 0);
+#endif
     if (ret == -1 && errno != EAGAIN) {
         PLUGIN_TRACE("[FD %i] error from sendfile(): %s",
                      socket_fd, strerror(errno));


### PR DESCRIPTION
Three files changed. One in liana.c that makes it use the freebsd sendfile.  Other in mk_event_kqueue.c that corrects the pointer errors. And third, in mk_file.h , because freebsd was showing a compiler error without time.h. 
Regards. 