### PR TITLE
mk_core/mk_utils.c and plugins/logger/logger.c: add _GNU_SOURCE

### DIFF
--- a/mk_core/mk_utils.c
+++ b/mk_core/mk_utils.c
@@ -17,6 +17,8 @@
  *  limitations under the License.
  */
 
+#define _GNU_SOURCE
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>

--- a/plugins/logger/logger.c
+++ b/plugins/logger/logger.c
@@ -17,6 +17,8 @@
  *  limitations under the License.
  */
 
+#define _GNU_SOURCE
+
 #include <monkey/mk_api.h>
 
 /* System Headers */


### PR DESCRIPTION
While O_CLOEXEC is specified in POSIX.1-2008, uClibc still guards it
with _GNU_SOURCE.  So, we define _GNU_SOURCE in files where open(2)
includes O_CLOEXEC in its flags.  This fixes the build on uClibc without
affecting glibc or musl.

Signed-off-by: Anthony G. Basile <blueness@gentoo.org>