### PR TITLE
mk_core: event*: high resolution interval support(#232)

### DIFF
--- a/include/monkey/mk_plugin.h
+++ b/include/monkey/mk_plugin.h
@@ -174,7 +174,7 @@ struct plugin_api
     struct mk_event_fdt *(*ev_get_fdt) ();
     int (*ev_add) (struct mk_event_loop *, int, int, uint32_t, void *);
     int (*ev_del) (struct mk_event_loop *, struct mk_event *);
-    int (*ev_timeout_create) (struct mk_event_loop *, int, void *);
+    int (*ev_timeout_create) (struct mk_event_loop *, int, int, void *);
     int (*ev_channel_create) (struct mk_event_loop *, int *, int *, void *);
     int (*ev_wait) (struct mk_event_loop *);
     char *(*ev_backend) ();

--- a/include/monkey/mk_plugin.h
+++ b/include/monkey/mk_plugin.h
@@ -174,7 +174,7 @@ struct plugin_api
     struct mk_event_fdt *(*ev_get_fdt) ();
     int (*ev_add) (struct mk_event_loop *, int, int, uint32_t, void *);
     int (*ev_del) (struct mk_event_loop *, struct mk_event *);
-    int (*ev_timeout_create) (struct mk_event_loop *, int, int, void *);
+    int (*ev_timeout_create) (struct mk_event_loop *, time_t, long, void *);
     int (*ev_channel_create) (struct mk_event_loop *, int *, int *, void *);
     int (*ev_wait) (struct mk_event_loop *);
     char *(*ev_backend) ();

--- a/mk_core/include/mk_core/mk_event.h
+++ b/mk_core/include/mk_core/mk_event.h
@@ -113,7 +113,7 @@ int mk_event_add(struct mk_event_loop *loop, int fd,
                  int type, uint32_t mask, void *data);
 int mk_event_del(struct mk_event_loop *loop, struct mk_event *event);
 int mk_event_timeout_create(struct mk_event_loop *loop,
-                            int sec, int nsec,void *data);
+                            time_t sec, long nsec,void *data);
 int mk_event_channel_create(struct mk_event_loop *loop,
                             int *r_fd, int *w_fd, void *data);
 int mk_event_wait(struct mk_event_loop *loop);

--- a/mk_core/include/mk_core/mk_event.h
+++ b/mk_core/include/mk_core/mk_event.h
@@ -113,6 +113,8 @@ int mk_event_add(struct mk_event_loop *loop, int fd,
                  int type, uint32_t mask, void *data);
 int mk_event_del(struct mk_event_loop *loop, struct mk_event *event);
 int mk_event_timeout_create(struct mk_event_loop *loop, int expire, void *data);
+int mk_event_high_resolution_timeout_create(struct mk_event_loop *loop,
+                                            int sec, int nsec, void *data);
 int mk_event_channel_create(struct mk_event_loop *loop,
                             int *r_fd, int *w_fd, void *data);
 int mk_event_wait(struct mk_event_loop *loop);

--- a/mk_core/include/mk_core/mk_event.h
+++ b/mk_core/include/mk_core/mk_event.h
@@ -112,9 +112,8 @@ void mk_event_loop_destroy(struct mk_event_loop *loop);
 int mk_event_add(struct mk_event_loop *loop, int fd,
                  int type, uint32_t mask, void *data);
 int mk_event_del(struct mk_event_loop *loop, struct mk_event *event);
-int mk_event_timeout_create(struct mk_event_loop *loop, int expire, void *data);
-int mk_event_high_resolution_timeout_create(struct mk_event_loop *loop,
-                                            int sec, int nsec, void *data);
+int mk_event_timeout_create(struct mk_event_loop *loop,
+                            int sec, int nsec,void *data);
 int mk_event_channel_create(struct mk_event_loop *loop,
                             int *r_fd, int *w_fd, void *data);
 int mk_event_wait(struct mk_event_loop *loop);

--- a/mk_core/mk_event.c
+++ b/mk_core/mk_event.c
@@ -117,17 +117,8 @@ int mk_event_del(struct mk_event_loop *loop, struct mk_event *event)
 }
 
 /* Create a new timer in the loop */
-int mk_event_timeout_create(struct mk_event_loop *loop, int expire, void *data)
-{
-    struct mk_event_ctx *ctx;
-
-    ctx = loop->data;
-    return _mk_event_timeout_create(ctx, expire, 0, data);
-}
-
-/* Create a new timer in the loop */
-int mk_event_high_resolution_timeout_create(struct mk_event_loop *loop,
-                            int sec, int nsec,  void *data)
+int mk_event_timeout_create(struct mk_event_loop *loop,
+                            int sec, int nsec, void *data)
 {
     struct mk_event_ctx *ctx;
 

--- a/mk_core/mk_event.c
+++ b/mk_core/mk_event.c
@@ -118,7 +118,7 @@ int mk_event_del(struct mk_event_loop *loop, struct mk_event *event)
 
 /* Create a new timer in the loop */
 int mk_event_timeout_create(struct mk_event_loop *loop,
-                            int sec, int nsec, void *data)
+                            time_t sec, long nsec, void *data)
 {
     struct mk_event_ctx *ctx;
 

--- a/mk_core/mk_event.c
+++ b/mk_core/mk_event.c
@@ -122,7 +122,17 @@ int mk_event_timeout_create(struct mk_event_loop *loop, int expire, void *data)
     struct mk_event_ctx *ctx;
 
     ctx = loop->data;
-    return _mk_event_timeout_create(ctx, expire, data);
+    return _mk_event_timeout_create(ctx, expire, 0, data);
+}
+
+/* Create a new timer in the loop */
+int mk_event_high_resolution_timeout_create(struct mk_event_loop *loop,
+                            int sec, int nsec,  void *data)
+{
+    struct mk_event_ctx *ctx;
+
+    ctx = loop->data;
+    return _mk_event_timeout_create(ctx, sec, nsec, data);
 }
 
 /* Create a new channel to distribute signals */

--- a/mk_core/mk_event_epoll.c
+++ b/mk_core/mk_event_epoll.c
@@ -146,7 +146,7 @@ static inline int _mk_event_del(struct mk_event_ctx *ctx, struct mk_event *event
 #ifdef HAVE_TIMERFD_CREATE
 /* Register a timeout file descriptor */
 static inline int _mk_event_timeout_create(struct mk_event_ctx *ctx,
-                                           int sec, int nsec, void *data)
+                                           time_t sec, long nsec, void *data)
 {
     int ret;
     int timer_fd;
@@ -194,8 +194,8 @@ static inline int _mk_event_timeout_create(struct mk_event_ctx *ctx,
 
 struct fd_timer {
     int fd;
-    int sec;
-    int nsec;
+    time_t sec;
+    long   nsec;
 };
 
 /*
@@ -235,7 +235,7 @@ void _timeout_worker(void *arg)
  * function through a thread and a pipe(2).
  */
 static inline int _mk_event_timeout_create(struct mk_event_ctx *ctx,
-                                           int sec, int nsec, void *data)
+                                           time_t sec, long nsec, void *data)
 {
     int ret;
     int fd[2];

--- a/mk_core/mk_event_epoll.c
+++ b/mk_core/mk_event_epoll.c
@@ -22,6 +22,7 @@
 #include <sys/epoll.h>
 #include <sys/eventfd.h>
 #include <sys/timerfd.h>
+#include <time.h>
 
 #include <mk_core/mk_event.h>
 #include <mk_core/mk_memory.h>
@@ -145,7 +146,7 @@ static inline int _mk_event_del(struct mk_event_ctx *ctx, struct mk_event *event
 #ifdef HAVE_TIMERFD_CREATE
 /* Register a timeout file descriptor */
 static inline int _mk_event_timeout_create(struct mk_event_ctx *ctx,
-                                           int expire, void *data)
+                                           int sec, int nsec, void *data)
 {
     int ret;
     int timer_fd;
@@ -155,11 +156,11 @@ static inline int _mk_event_timeout_create(struct mk_event_ctx *ctx,
     mk_bug(!data);
 
     /* expiration interval */
-    its.it_interval.tv_sec  = expire;
-    its.it_interval.tv_nsec = 0;
+    its.it_interval.tv_sec  = sec;
+    its.it_interval.tv_nsec = nsec;
 
     /* initial expiration */
-    its.it_value.tv_sec  = time(NULL) + expire;
+    its.it_value.tv_sec  = time(NULL) + sec;
     its.it_value.tv_nsec = 0;
 
     timer_fd = timerfd_create(CLOCK_REALTIME, 0);
@@ -193,7 +194,8 @@ static inline int _mk_event_timeout_create(struct mk_event_ctx *ctx,
 
 struct fd_timer {
     int fd;
-    int expiration;
+    int sec;
+    int nsec;
 };
 
 /*
@@ -205,11 +207,15 @@ void _timeout_worker(void *arg)
     int ret;
     uint64_t val = 1;
     struct fd_timer *timer;
+    struct timespec t_spec;
 
     timer = (struct fd_timer *) arg;
+    t_spec.tv_sec  = timer->sec;
+    t_spec.tv_nsec = timer->nsec;
+
     while (1) {
         /* sleep for a while */
-        sleep(timer->expiration);
+        nanosleep(&t_spec, NULL);
 
         /* send notification */
         ret = write(timer->fd, &val, sizeof(uint64_t));
@@ -229,7 +235,7 @@ void _timeout_worker(void *arg)
  * function through a thread and a pipe(2).
  */
 static inline int _mk_event_timeout_create(struct mk_event_ctx *ctx,
-                                           int expire, void *data)
+                                           int sec, int nsec, void *data)
 {
     int ret;
     int fd[2];
@@ -257,8 +263,9 @@ static inline int _mk_event_timeout_create(struct mk_event_ctx *ctx,
     event->mask = MK_EVENT_READ;
 
     /* Compose the timer context, this is released inside the worker thread */
-    timer->fd = fd[1];
-    timer->expiration = expire;
+    timer->fd   = fd[1];
+    timer->sec  = sec;
+    timer->nsec = nsec;
 
     /* Now the dirty workaround, create a thread */
     mk_utils_worker_spawn(_timeout_worker, timer);

--- a/mk_core/mk_event_kqueue.c
+++ b/mk_core/mk_event_kqueue.c
@@ -149,7 +149,7 @@ static inline int _mk_event_del(struct mk_event_ctx *ctx, struct mk_event *event
 }
 
 static inline int _mk_event_timeout_create(struct mk_event_ctx *ctx,
-                                           int sec, int nsec, void *data)
+                                           time_t sec, long nsec, void *data)
 {
     int fd;
     int ret;

--- a/mk_core/mk_event_kqueue.c
+++ b/mk_core/mk_event_kqueue.c
@@ -149,7 +149,7 @@ static inline int _mk_event_del(struct mk_event_ctx *ctx, struct mk_event *event
 }
 
 static inline int _mk_event_timeout_create(struct mk_event_ctx *ctx,
-                                           int expire, void *data)
+                                           int sec, int nsec, void *data)
 {
     int fd;
     int ret;
@@ -176,7 +176,7 @@ static inline int _mk_event_timeout_create(struct mk_event_ctx *ctx,
     EV_SET(&ke, fd, EVFILT_TIMER, EV_ADD, NOTE_SECONDS, expire, event);
 #else
     /* Other BSD have no NOTE_SECONDS & specify milliseconds */
-    EV_SET(&ke, fd, EVFILT_TIMER, EV_ADD, 0, expire * 1000, event);
+    EV_SET(&ke, fd, EVFILT_TIMER, EV_ADD, 0, (sec * 1000) + (nsec / 1000000) , event);
 #endif
     ret = kevent(ctx->kfd, &ke, 1, NULL, 0, NULL);
     if (ret < 0) {

--- a/mk_core/mk_event_kqueue.c
+++ b/mk_core/mk_event_kqueue.c
@@ -173,7 +173,8 @@ static inline int _mk_event_timeout_create(struct mk_event_ctx *ctx,
 
 #ifdef NOTE_SECONDS
     /* FreeBSD or LINUX_KQUEUE defined */
-    EV_SET(&ke, fd, EVFILT_TIMER, EV_ADD, NOTE_SECONDS, expire, event);
+    /* TODO : high resolution interval support. */
+    EV_SET(&ke, fd, EVFILT_TIMER, EV_ADD, NOTE_SECONDS, sec, event);
 #else
     /* Other BSD have no NOTE_SECONDS & specify milliseconds */
     EV_SET(&ke, fd, EVFILT_TIMER, EV_ADD, 0, (sec * 1000) + (nsec / 1000000) , event);

--- a/mk_core/mk_event_select.c
+++ b/mk_core/mk_event_select.c
@@ -22,9 +22,9 @@
 #include <time.h>
 
 struct fd_timer {
-    int fd;
-    int sec;
-    int nsec;
+    int    fd;
+    time_t sec;
+    long   nsec;
 };
 
 static inline void *_mk_event_loop_create(int size)
@@ -175,7 +175,7 @@ void _timeout_worker(void *arg)
  * and a thread, this thread writes a byte upon the expiration time is reached.
  */
 static inline int _mk_event_timeout_create(struct mk_event_ctx *ctx,
-                                           int sec, int nsec, void *data)
+                                           time_t sec, long nsec, void *data)
 {
     int ret;
     int fd[2];

--- a/mk_core/mk_event_select.c
+++ b/mk_core/mk_event_select.c
@@ -19,10 +19,12 @@
 
 #include <sys/select.h>
 #include <mk_core/mk_event.h>
+#include <time.h>
 
 struct fd_timer {
     int fd;
-    int expiration;
+    int sec;
+    int nsec;
 };
 
 static inline void *_mk_event_loop_create(int size)
@@ -144,11 +146,15 @@ void _timeout_worker(void *arg)
     int ret;
     uint64_t val = 1;
     struct fd_timer *timer;
+    struct timespec t_spec;
 
     timer = (struct fd_timer *) arg;
+    t_spec.tv_sec  = timer->sec;
+    t_spec.tv_nsec = timer->nsec;
+
     while (1) {
         /* sleep for a while */
-        sleep(timer->expiration);
+        nanosleep(&t_spec, NULL);        
 
         /* send notification */
         ret = write(timer->fd, &val, sizeof(uint64_t));
@@ -169,7 +175,7 @@ void _timeout_worker(void *arg)
  * and a thread, this thread writes a byte upon the expiration time is reached.
  */
 static inline int _mk_event_timeout_create(struct mk_event_ctx *ctx,
-                                           int expire, void *data)
+                                           int sec, int nsec, void *data)
 {
     int ret;
     int fd[2];
@@ -198,8 +204,9 @@ static inline int _mk_event_timeout_create(struct mk_event_ctx *ctx,
     event->mask = MK_EVENT_READ;
 
     /* Compose the timer context, this is released inside the worker thread */
-    timer->fd = fd[1];
-    timer->expiration = expire;
+    timer->fd   = fd[1];
+    timer->sec  = sec;
+    timer->nsec = nsec;
 
     /* Now the dirty workaround, create a thread */
     mk_utils_worker_spawn(_timeout_worker, timer);

--- a/mk_server/mk_server.c
+++ b/mk_server/mk_server.c
@@ -404,7 +404,7 @@ void mk_server_worker_loop()
     /* create a new timeout file descriptor */
     server_timeout = mk_mem_malloc(sizeof(struct mk_server_timeout));
     MK_TLS_SET(mk_tls_server_timeout, server_timeout);
-    timeout_fd = mk_event_timeout_create(evl, mk_config->timeout, server_timeout);
+    timeout_fd = mk_event_timeout_create(evl, mk_config->timeout, 0, server_timeout);
 
     while (1) {
         mk_event_wait(evl);


### PR DESCRIPTION
Issue #232 

I add new API mk_event_high_resolution_timeout_create().
Its argument is almost same as mk_event_timeout_create.
You can additionally pass nanosecond to new API.
Then you can handle more precise timer event.

## Test result of fluent-bit plugin, in_head

Sorry , I have no idea to test new API using monkey.
So, I have tested fluent-bit.

The plugin is configured to read /proc/uptime  per 1500ms.
If correctly work, read timestamp value will increase by 1500ms.
(I have not tested on BSD.
 Build error happened on FreeBSD when include ucontext.h , i will throw a patch.)

I checked symbol with string and nm command.

### epoll

```
$ strings bin/fluent-bit |grep epoll
epoll_wait
epoll_ctl
epoll_create1
/home/taka/git/oss/pull_req/fluentbit_env/fluent-bit/lib/monkey/mk_core/mk_event_epoll.c
epoll_create
epoll_ctl
epoll
$ bin/fluent-bit -i head -o stdout -c ../../in_head.conf 
Fluent-Bit v0.7.0
Copyright (C) Treasure Data

[2016/03/06 14:06:36] [ info] starting engine
[0] [1457240797, {"head"=>"50420.62 4"}]
[1] [1457240798, {"head"=>"50422.12 4"}]
[2] [1457240800, {"head"=>"50423.62 4"}]
```

### select
```
$ strings bin/fluent-bit |grep select
select
point format selected: %d
point format selected: %d
selected certificate chain, certificate
selected ciphersuite: %s
CIPHER - The selected feature is not available
MD - The selected feature is not available
$ bin/fluent-bit -i head -o stdout -c ../../in_head.conf 
Fluent-Bit v0.7.0
Copyright (C) Treasure Data

[2016/03/06 14:03:44] [ info] starting engine
[0] [1457240625, {"head"=>"50248.63 4"}]
[1] [1457240626, {"head"=>"50250.13 4"}]
[2] [1457240628, {"head"=>"50251.63 4"}]
```

### in_head.conf
```
# Head Input
# ==========
[HEAD]
    # File
    # ====
    # File path. e.g. /proc/uptime
    #
    #File    /proc/uptime
    File /proc/uptime

    # Buf_Size
    # ====
    # Buffer size to read file.
    Buf_Size 10

    # Total Interval 
    #     = Interval Sec + ( Interval Nsec * 1000 * 1000 * 1000 )
    #

    # Interval Sec
    # ====
    # Read interval (sec) Default 1
    Interval_Sec 1

    # Interval NSec
    # ====
    # Read interval (nsec) Default 0
    Interval_NSec 500000000
```

Signed-off-by: nokute78 <nokute78@gmail.com>