### PR TITLE
Monkey: RFC1867 implementation for single file upload

### DIFF
--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -57,7 +57,7 @@ macro(MK_BUILD_PLUGIN name)
       # struct reference on mk_static_plugins.h
       set(static_plugins "${static_plugins}monkey-${name}-static;")
       set(STATIC_PLUGINS_INIT "${STATIC_PLUGINS_INIT}\n    p = &mk_plugin_${name};\n    mk_list_add(&p->_head, &mk_config->plugins);\n")
-      set(STATIC_PLUGINS_DECL "${STATIC_PLUGINS_DECL}struct mk_plugin mk_plugin_${name};\n")
+      set(STATIC_PLUGINS_DECL "${STATIC_PLUGINS_DECL}extern struct mk_plugin mk_plugin_${name};\n")
 
       # append message to stdout
       set(mode "[== static ==]")


### PR DESCRIPTION
The fact is that today Monkey caches the whole HTTP request body in the process heap (realloced) for any kind of file upload case and it passes the file to plugins like FCGI etc. in several chunks, only after complete file is downloaded within Monkey's heap area. Now for bigger files (in hundreds on MBs or GBs) or for systems with low RAM, this kind of model is actually inefficient. Not only it stresses the process heap and the memory manager (due to constant realloc), the real space (RAM/flash) requirement is actually almost double the file size (because the applications like FCGI also creates separate copy of the same file either in RAM file system or in flash) and unless the entire file is sent to plugins, Monkey doesn't free the file copy kept in the process heap. This causes the low RAM embedded systems to go for OOM for larger file upload scenarios.

This can be solved in 2 ways:
>> Either implement a pass through mechanism in Monkey and if seen file upload request, keep passing the request body data to plugin applications (FCGI etc.) as and when data arrives and let the plugins reassemble all the parts of the data in file system and rebuild the file back. Something very similar is proposed here: https://github.com/monkey/monkey/issues/228. The disadvantage of this model is that we might compromise on some security aspects. Also this means we expect the plugins to be HTTP protocol aware.

>> The alternate model is to directly cache the file data to file system instead of process heap and once the whole request body is downloaded, verify the RFC1867 parameters and then pass the file path and the form attributes to FCGI.

The attached patch tries to implement single file upload using 'multipart/form-data' as described in RFC1867. In future we can generalize the patch to support multiple file upload in same form using 'multipart/mixed'. But at this moment my requirement is limited to single file upload. Hence I would request to kindly review the attached patch file for the same implementation and let me know your comments to improve it. Also the patch is limited to my immediate required platform Linux. However the logic remains generic and we can easily add support for other platforms whenever required.



[Monkey_RFC1867_Single_File_Upload_Changes_Linux_Patch.txt](https://github.com/monkey/monkey/files/172811/Monkey_RFC1867_Single_File_Upload_Changes_Linux_Patch.txt)

