### PR TITLE
CMakeLists: lookup event-loop mechanism at root CMakeLists.txt (#236)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -350,3 +350,21 @@ if(NOT SKIP_EMPTY_DIRS)
   install(DIRECTORY DESTINATION ${MK_PATH_PIDPATH})
   install(DIRECTORY DESTINATION ${MK_PATH_LOG})
 endif()
+
+# Lookup event-loop mechanism: do we need to fallback to select(2) ?
+check_c_source_compiles("
+  #include <sys/epoll.h>
+  int main() {
+     return epoll_create(1);
+  }" HAVE_EPOLL)
+
+check_c_source_compiles("
+  #include <sys/event.h>
+  int main() {
+     return kqueue();
+  }" HAVE_KQUEUE)
+
+if (NOT HAVE_EPOLL AND NOT HAVE_KQUEUE)
+  message(STATUS "Event loop backend > select(2)")
+  add_definitions(-DEVENT_SELECT)
+endif()

--- a/mk_core/CMakeLists.txt
+++ b/mk_core/CMakeLists.txt
@@ -14,24 +14,6 @@ set(src
   mk_thread_channel.c
   )
 
-# Lookup event-loop mechanism: do we need to fallback to select(2) ?
-check_c_source_compiles("
-  #include <sys/epoll.h>
-  int main() {
-     return epoll_create(1);
-  }" HAVE_EPOLL)
-
-check_c_source_compiles("
-  #include <sys/event.h>
-  int main() {
-     return kqueue();
-  }" HAVE_KQUEUE)
-
-if (NOT HAVE_EPOLL AND NOT HAVE_KQUEUE)
-  message(STATUS "Event loop backend > select(2)")
-  add_definitions(-DEVENT_SELECT)
-endif()
-
 # Validate timerfd_create()
 check_c_source_compiles("
   #include <sys/timerfd.h>


### PR DESCRIPTION
Some plugins refer mk_event.h indirectly.
However, the result of lookup is only applied codes of mk_core/ and its subdirs.
So, a code under plugins/ couldn't find proper mk_event_*.h.

I added lookup routine at the bottom of root CMakeLists.txt.
It's because cmake error was occured when I added them at the middle of the file.

Signed-off-by: nokute78 <nokute78@gmail.com>