### PR TITLE
fcgi: support for multi socket.

### DIFF
--- a/plugins/fastcgi/fastcgi.h
+++ b/plugins/fastcgi/fastcgi.h
@@ -31,6 +31,4 @@ struct mk_fcgi_conf {
     char *server_port;
 };
 
-struct mk_fcgi_conf fcgi_conf;
-
 #endif

--- a/plugins/fastcgi/fcgi_handler.c
+++ b/plugins/fastcgi/fcgi_handler.c
@@ -896,6 +896,7 @@ int cb_fastcgi_on_connect(void *data)
 }
 
 struct fcgi_handler *fcgi_handler_new(struct mk_plugin *plugin,
+                                      struct mk_fcgi_conf *fcgi_conf,
                                       struct mk_http_session *cs,
                                       struct mk_http_request *sr)
 {
@@ -947,13 +948,13 @@ struct fcgi_handler *fcgi_handler_new(struct mk_plugin *plugin,
     h->buf_len = FCGI_RECORD_HEADER_SIZE;
 
     /* Request and async connection to the server */
-    if (fcgi_conf.server_addr) {
-        h->server_fd = mk_api->socket_connect(fcgi_conf.server_addr,
-                                              atoi(fcgi_conf.server_port),
+    if (fcgi_conf->server_addr) {
+        h->server_fd = mk_api->socket_connect(fcgi_conf->server_addr,
+                                              atoi(fcgi_conf->server_port),
                                               MK_TRUE);
     }
-    else if (fcgi_conf.server_path) {
-        h->server_fd = mk_api->socket_open(fcgi_conf.server_path, MK_TRUE);
+    else if (fcgi_conf->server_path) {
+        h->server_fd = mk_api->socket_open(fcgi_conf->server_path, MK_TRUE);
     }
 
     if (h->server_fd == -1) {

--- a/plugins/fastcgi/fcgi_handler.h
+++ b/plugins/fastcgi/fcgi_handler.h
@@ -122,6 +122,7 @@ static inline void fcgi_encode16(void *a, unsigned b)
 }
 
 struct fcgi_handler *fcgi_handler_new(struct mk_plugin *plugin,
+                                      struct mk_fcgi_conf *fcgi_conf,
                                       struct mk_http_session *cs,
                                       struct mk_http_request *sr);
 


### PR DESCRIPTION

Each config file can redirect request through an dedicated fcgi server.
It use the first param from the handler to match on **ServerName**.
If no fcgi config found, use first.

> This is just a daft, I'm open to discuss about this implementation

Already tested on 1.6.9, but test needed on master.

Exemple:
server.site:
```
[HANDLERS]
....
MATCH 
/myfirstapi/* fastcgi foo
/mysecondapi/* fastcgi bar
```

/etc/monkey/plugins/fastcgi/fastcgi-first.conf
```
[FASTCGI_SERVER]
    ServerName foo
```

/etc/monkey/plugins/fastcgi/fastcgi-second.conf
```
[FASTCGI_SERVER]
    ServerName bar
```