### PR TITLE
fcgi: fix deferring.

### DIFF
--- a/plugins/fastcgi/fcgi_handler.c
+++ b/plugins/fastcgi/fcgi_handler.c
@@ -565,7 +565,9 @@ int fcgi_exit(struct fcgi_handler *handler)
      * some corruption. If there is still some data enqueued, just
      * defer the exit process.
      */
-    if (handler->eof == MK_FALSE && handler->active == MK_TRUE) {
+    if (mk_channel_is_empty(handler->cs->channel) != 0 &&
+        handler->eof == MK_FALSE &&
+        handler->active == MK_TRUE) {
         MK_TRACE("[fastcgi=%i] deferring exit, EOF stream",
                  handler->server_fd);
 


### PR DESCRIPTION
we should defer the exit process ONLY if the socket is not empty.

Otherwise, the request never finish in some cases.

This fix could also apply to 1.6 branch