### PR TITLE
build:  fix "-fpic unknown compiler option" warnings on Windows

### DIFF
--- a/mk_server/CMakeLists.txt
+++ b/mk_server/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 set(src
   monkey.c

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -1,5 +1,5 @@
 set(static_plugins "" CACHE INTERNAL "static_plugins")
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 # CHECK_STATIC_PLUGIN: Check if a plugin will be linked statically
 macro(CHECK_STATIC_PLUGIN name)


### PR DESCRIPTION
Cmake provides a cross-platform way to mark the build target as
platform-independent. Let's make use of this feature, in lieu of
tweaking `C_FLAGS` manually.

Main issue link: https://github.com/fluent/fluent-bit/issues/960