### PR TITLE
core: rconf: define "PATH_MAX" macro for Windows

### DIFF
--- a/mk_core/mk_rconf.c
+++ b/mk_core/mk_rconf.c
@@ -23,13 +23,16 @@
 #include <string.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <unistd.h>
 #include <glob.h>
 
 #include <mk_core/mk_rconf.h>
 #include <mk_core/mk_utils.h>
 #include <mk_core/mk_string.h>
 #include <mk_core/mk_list.h>
+
+#ifdef _MSC_VER
+#define PATH_MAX MAX_PATH
+#endif
 
 /* Raise a configuration schema error */
 static void mk_config_error(const char *path, int line, const char *msg)


### PR DESCRIPTION
Insert a simple macro to make `mk_rconf.c` compilable on MSVC.

Also I removed <unistd.h> from the header list, since it should
be included via <mk_core/unistd.h> for portability reasons.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>