### PR TITLE
core: rconf: use _fullpath in place of realpath on Windows

### DIFF
--- a/mk_core/mk_rconf.c
+++ b/mk_core/mk_rconf.c
@@ -446,7 +446,11 @@ static int mk_rconf_path_set(struct mk_rconf *conf, char *file)
     char *end;
     char path[PATH_MAX + 1];
 
+#ifdef _MSC_VER
+    p = _fullpath(path, file, PATH_MAX + 1);
+#else
     p = realpath(file, path);
+#endif
     if (!p) {
         return -1;
     }


### PR DESCRIPTION
`realpath()` function is not provided on Windows, so add ifdefs to
swtich to `_fullpath()` on MSVC. These two functions should have
the same functionality.

See: https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/fullpath-wfullpath

Main issue link: https://github.com/fluent/fluent-bit/issues/960