### PR TITLE
core: dep_unistd: define ssize_t as SSIZE_T

### DIFF
--- a/include/monkey/mk_core/mk_dep_unistd.h
+++ b/include/monkey/mk_core/mk_dep_unistd.h
@@ -38,7 +38,7 @@
 #define lseek _lseek
 /* read, write, and close are NOT being #defined here, because while there are file handle specific versions for Windows, they probably don't work for sockets. You need to look at your app and consider whether to call e.g. closesocket(). */
 
-#define ssize_t int
+#define ssize_t SSIZE_T
 
 #define STDIN_FILENO 0
 #define STDOUT_FILENO 1


### PR DESCRIPTION
On Windows, we cannot use ssize_t but can actually use SSIZE_T.
This data type is probably what we need here.

> SSIZE_T: A signed version of SIZE_T.
>
> https://docs.microsoft.com/en-us/windows/desktop/winprog/windows-data-types

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>