### PR TITLE
core: event: fix SIGSEGV on cancelling events on Windows

### DIFF
--- a/mk_core/mk_event_libevent.c
+++ b/mk_core/mk_event_libevent.c
@@ -148,10 +148,10 @@ static inline int _mk_event_del(struct mk_event_ctx *ctx, struct mk_event *event
 
     ev_map = event->data;
     if (ev_map->pipe[0] > 0) {
-        close(ev_map->pipe[0]);
+        evutil_closesocket(ev_map->pipe[0]);
     }
     if (ev_map->pipe[1] > 0) {
-        close(ev_map->pipe[1]);
+        evutil_closesocket(ev_map->pipe[1]);
     }
 
     ret = event_del(ev_map->event);


### PR DESCRIPTION
Right now `_mk_event_del()` closes sockets using `close(2)`. It does not
work on Windows, since they are implemented using the loopback
interface on localhost and we have to close them with `closecocket()`.

This patch fixes the bug by using `evutil_closesocket()`, which should
abstract the platform-specific issue away.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>