### PR TITLE
core: event: introduce mk_event_closesocket() function

### DIFF
--- a/include/monkey/mk_core/mk_event.h
+++ b/include/monkey/mk_core/mk_event.h
@@ -74,6 +74,12 @@
     #include "mk_event_kqueue.h"
 #endif
 
+#if defined(_WIN32)
+    #define mk_event_closesocket(s) evutil_closesocket(s)
+#else
+    #define mk_event_closesocket(s) close(s)
+#endif
+
 /* Event reported by the event loop */
 struct mk_event {
     int      fd;       /* monitored file descriptor */


### PR DESCRIPTION
Previously the downstream programs had to figure out the correct
function to close sockets depending on the backend library in use.
(i.e. use evutil_socketclose if the mk_core's backend is libevent)

Failing to do so would result in segmentation faults and it was
somewhat cumbersome. With this patch library users can now call
mk_event_closesocket() to close sockets safely.

Part of: fluent/fluent-bit/issues/960