### PR TITLE
core: event: handle nanoseconds properly in the libevent backend

### DIFF
--- a/mk_core/mk_event_libevent.c
+++ b/mk_core/mk_event_libevent.c
@@ -194,7 +194,7 @@ static inline int _mk_event_timeout_create(struct mk_event_ctx *ctx,
     evutil_socket_t fd[2];
     struct event *libev;
     struct mk_event *event;
-    struct timeval timev = {sec, nsec};
+    struct timeval timev = {sec, nsec / 1000}; /* (tv_sec, tv_usec} */
     struct ev_map *ev_map;
 
     if (evutil_socketpair(AF_UNIX, SOCK_STREAM, 0, fd) == -1) {


### PR DESCRIPTION
A timeval struct is a pair of {sec, usec}, so we need to convert
the wait interval (which is in nanoseconds) to microseconds before
assigning to tv_usec.

This fixes the bug that mk_event_timeout_create() sometimes never
timeouts on Windows.

Part of fluent/fluent-bit/issues/960