### PR TITLE
deps: Make buildable BSD based rbtree with MSVC

### DIFF
--- a/deps/rbtree/rbtree.h
+++ b/deps/rbtree/rbtree.h
@@ -33,7 +33,11 @@ extern "C" {
 /**
  * The tagged branch is unlikely to be taken
  */
+#ifdef _MSC_VER
+#define RB_UNLIKELY(x) (!!x) /* MSVC does not have __builtin_expect equivalent. */
+#else
 #define RB_UNLIKELY(x) __builtin_expect(!!(x), 0)
+#endif
 /**@}*/
 
 /** \defgroup rb_tree_state State Structures


### PR DESCRIPTION
MSVC does not have `__builtin_expect()` function for optimization hints.

Now, fluent-bit's stream processor feature depends on rbtree in monkey.
We also should make buildable with MSVC to work with stream processor on Windows.

Signed-off-by: Hiroshi Hatake <hatake@clear-code.com>