### PR TITLE
core: file: make mk_file.c compilable on Windows

### DIFF
--- a/mk_core/CMakeLists.txt
+++ b/mk_core/CMakeLists.txt
@@ -35,10 +35,8 @@ endif()
 check_c_source_compiles("
   #include <sys/types.h>
   #include <sys/stat.h>
-  #include <unistd.h>
   int main() {
-    int x = S_IXUSR;
-    S_ISLNK(0);
+    struct stat st;
     return 0;
   }" HAVE_STAT_H)
 if (HAVE_STAT_H)

--- a/mk_core/mk_file.c
+++ b/mk_core/mk_file.c
@@ -29,9 +29,10 @@
 #include "mk_core.h"
 
 #ifdef _WIN32
-#include <mk_core/mk_dep_unistd.h>
-#else
-#include <unistd.h>
+#define S_ISDIR(m) (((m) & S_IFMT) == S_IFDIR)
+#define S_ISLNK(m) (0)
+#define O_NONBLOCK (0)
+#define lstat stat
 #endif
 
 int mk_file_get_info(const char *path, struct file_info *f_info, int mode)
@@ -128,7 +129,7 @@ char *mk_file_to_buffer(const char *path)
         return NULL;
     }
 
-    if (!(fp = fopen(path, "r"))) {
+    if (!(fp = fopen(path, "rb"))) {
         return NULL;
     }
 


### PR DESCRIPTION
The implication of this patch is that the modules in Fluent Bit that
rely on `mk_file_to_buffer()` now can be compiled and linked on Windows.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>