### PR TITLE
mk_core: mk_rconf: Fix potential overrun in mk_rconf_read_glob()

### DIFF
--- a/mk_core/mk_rconf.c
+++ b/mk_core/mk_rconf.c
@@ -34,6 +34,7 @@
 
 #ifdef _WIN32
 #include <Windows.h>
+#include <strsafe.h>
 #define PATH_MAX MAX_PATH
 #endif
 
@@ -506,8 +507,13 @@ static int mk_rconf_read_glob(struct mk_rconf *conf, const char *path)
         /* Create a path (prefix + filename + suffix) */
         memcpy(buf, path, p0 - path + 1);
         buf[p0 - path + 1] = '\0';
-        strcat(buf, data.cFileName);
-        strcat(buf, p1);
+
+        if (FAILED(StringCchCatA(buf, MAX_PATH, data.cFileName))) {
+            continue;
+        }
+        if (FAILED(StringCchCatA(buf, MAX_PATH, p1))) {
+            continue;
+        }
 
         if (strchr(p1, '*')) {
             mk_rconf_read_glob(conf, buf); /* recursive */


### PR DESCRIPTION
Justin Angra pointed out that these strcat() have a potential overrun
bug. His observation is correct. In particular, when the input string
`path` is very long, it can overrun the buffer while appending `p1`.

This patch fixes the issue by using a safer variant (strcat_s), and
check the return code explicitly.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>