### PR TITLE
monkey: libevent: import version detection fix from libevent

### DIFF
--- a/mk_core/deps/libevent/cmake/VersionViaGit.cmake
+++ b/mk_core/deps/libevent/cmake/VersionViaGit.cmake
@@ -2,9 +2,8 @@
 # git to determine the parent tag. And if found the macro
 # will attempt to parse them in the github tag fomat
 #
-# Usful for auto-versionin in ou CMakeLists
+# Useful for auto-versioning in our CMakeLists
 #
-#  EVENT_GIT___VERSION_FOUND - Version variables foud
 #  EVENT_GIT___VERSION_MAJOR - Major version.
 #  EVENT_GIT___VERSION_MINOR - Minor version
 #  EVENT_GIT___VERSION_STAGE - Stage version
@@ -12,7 +11,6 @@
 # Example usage:
 #
 # event_fuzzy_version_from_git()
-# if (EVENT_GIT___VERSION_FOUND)
 #    message("Libvent major=${EVENT_GIT___VERSION_MAJOR}")
 #    message("        minor=${EVENT_GIT___VERSION_MINOR}")
 #    message("        patch=${EVENT_GIT___VERSION_PATCH}")
@@ -22,32 +20,47 @@
 include(FindGit)
 
 macro(event_fuzzy_version_from_git)
-	set(EVENT_GIT___VERSION_FOUND FALSE)
-
 	# set our defaults.
 	set(EVENT_GIT___VERSION_MAJOR 2)
-	set(EVENT_GIT___VERSION_MINOR 1)
-	set(EVENT_GIT___VERSION_PATCH 7)
-	set(EVENT_GIT___VERSION_STAGE "beta")
+	set(EVENT_GIT___VERSION_MINOR 2)
+	set(EVENT_GIT___VERSION_PATCH 0)
+	set(EVENT_GIT___VERSION_STAGE "alpha-dev")
 
 	find_package(Git)
 
 	if (GIT_FOUND)
 		execute_process(
 			COMMAND
-				${GIT_EXECUTABLE} describe --abbrev=0
+				${GIT_EXECUTABLE} describe --abbrev=0 --always
 			WORKING_DIRECTORY
 				${PROJECT_SOURCE_DIR}
 			RESULT_VARIABLE
 				GITRET
 			OUTPUT_VARIABLE
-				GITVERSION)
+				GITVERSION
+			OUTPUT_STRIP_TRAILING_WHITESPACE
+		)
 
-			if (GITRET EQUAL 0)
-				string(REGEX REPLACE "^release-([0-9]+)\\.([0-9]+)\\.([0-9]+)-(.*)"       "\\1" EVENT_GIT___VERSION_MAJOR ${GITVERSION})
-				string(REGEX REPLACE "^release-([0-9]+)\\.([0-9]+)\\.([0-9]+)-(.*)"       "\\2" EVENT_GIT___VERSION_MINOR ${GITVERSION})
-				string(REGEX REPLACE "^release-([0-9]+)\\.([0-9]+)\\.([0-9]+)-(.*)"       "\\3" EVENT_GIT___VERSION_PATCH ${GITVERSION})
-				string(REGEX REPLACE "^release-([0-9]+)\\.([0-9]+)\\.([0-9]+)-([aA-zZ]+)" "\\4" EVENT_GIT___VERSION_STAGE ${GITVERSION})
+		string(REGEX REPLACE "[\\._-]" ";" VERSION_LIST "${GITVERSION}")
+		if(VERSION_LIST)
+			list(LENGTH VERSION_LIST VERSION_LIST_LENGTH)
+		endif()
+
+		if ((GITRET EQUAL 0) AND (VERSION_LIST_LENGTH EQUAL 5))
+			list(GET VERSION_LIST 1 _MAJOR)
+			list(GET VERSION_LIST 2 _MINOR)
+			list(GET VERSION_LIST 3 _PATCH)
+			list(GET VERSION_LIST 4 _STAGE)
+
+			set(_DEFAULT_VERSION "${EVENT_GIT___VERSION_MAJOR}.${EVENT_GIT___VERSION_MINOR}.${EVENT_GIT___VERSION_PATCH}-${EVENT_GIT___VERSION_STAGE}")
+			set(_GIT_VERSION     "${_MAJOR}.${_MINOR}.${_PATCH}-${_STAGE}")
+
+			if (${_DEFAULT_VERSION} VERSION_LESS ${_GIT_VERSION})
+				set(EVENT_GIT___VERSION_MAJOR ${_MAJOR})
+				set(EVENT_GIT___VERSION_MINOR ${_MINOR})
+				set(EVENT_GIT___VERSION_PATCH ${_PATCH})
+				set(EVENT_GIT___VERSION_STAGE ${_STAGE})
 			endif()
 		endif()
+	endif()
 endmacro()


### PR DESCRIPTION
libevent's CMakeLists.txt is buggy. In particular, when an
annotated tag is attached to a commit, the build process crashes.

For example, if we do:

    % cd fluent-bit/build/
    % git tag -a v1.5
    % cmake ..
    % cmake --build .

... it results in the following error:

    event-config.h(14): error C2001: newline in constant

Luckly this bug is already fixed in the upstream project. This
ports the relevant fix to mk_core/deps/libevent.

Link: https://github.com/libevent/libevent/commit/a9aa2b36
LInk: https://github.com/libevent/libevent/commit/d65e3e1d
Signed-off-by: Fujimoto Seiji <fujimoto@ceptord.net>