### PR TITLE
server: scheduler: Do not drop other HTTP connections on network error

### DIFF
--- a/include/monkey/mk_scheduler.h
+++ b/include/monkey/mk_scheduler.h
@@ -337,5 +337,7 @@ int mk_sched_send_signal(struct mk_server *server, uint64_t val);
 int mk_sched_workers_join(struct mk_server *server);
 int mk_sched_threads_purge(struct mk_sched_worker *sched);
 int mk_sched_threads_destroy_all(struct mk_sched_worker *sched);
+int mk_sched_threads_destroy_conn(struct mk_sched_worker *sched,
+                                  struct mk_sched_conn *conn);
 
 #endif


### PR DESCRIPTION
When Monkey detects a broken connection (not necessarily an error;
just a closed connection for most cases), it tries to purge all the
HTTP sessions in the worker.

This is dangerous because a HTTP worker can process several requests
concurrently, so the cleanup effort can inadvertently drop other
non-broken connections:

    +--------+
    |        |--[ REQ1 ] -> <CLOSED> -> mk_sched_threads_destroy_all()
    | WORKER |                               |
    |        |--[ REQ2 ] <-------------------+
    +--------+

In such case, a concurrent connection (REQ2 in the above diagram) will
exit abruptly while processing, causing its client to emit "unexpected
EOF" error.

This patch possibly fixes the bug "Fluent Bit is sometimes mis-detected
as crashed due to random broken responses".

Signed-off-by: Fujimoto Seiji <fujimoto@ceptord.net>