### PR TITLE
mk_core: mk_rconf: Be more verbose on indentation errors

### DIFF
--- a/mk_core/mk_rconf.c
+++ b/mk_core/mk_rconf.c
@@ -169,6 +169,31 @@ static int mk_rconf_meta_add(struct mk_rconf *conf, char *buf, int len)
     return 0;
 }
 
+static int check_indent(const char *line, const char *indent)
+{
+    while (*line == *indent && *indent) {
+        line++;
+        indent++;
+    }
+
+    if (*indent != '\0') {
+        if (isblank(*line)) {
+            mk_err("[config] Inconsistent use of tab and space");
+        }
+        else {
+            mk_err("[config] Indentation level is too low");
+        }
+        return -1;
+    }
+
+    if (isblank(*line)) {
+        mk_err("[config] Extra indentation level found");
+        return -1;
+    }
+
+    return 0;
+}
+
 /* To call this function from mk_rconf_read */
 static int mk_rconf_read_glob(struct mk_rconf *conf, const char * path);
 
@@ -337,7 +362,7 @@ static int mk_rconf_read(struct mk_rconf *conf, const char *path)
         }
 
         /* Validate indentation level */
-        if (strncmp(buf, indent, indent_len) != 0 ||
+        if (check_indent(buf, indent) < 0) {
             isblank(buf[indent_len]) != 0) {
             mk_config_error(path, line, "Invalid indentation level");
             mk_mem_free(key);


### PR DESCRIPTION
This extends the verification logic for indentation, so that
users can distinguish the following three failure modes.

    [INPUT]
      Name dummy
     Tag 1

    => (1) Indentation level is too low

    [INPUT]
        Name dummy
    \tTag 1

    => (2) Incositent use of tab and space

    [INPUT]
      Name dummy
       Tag 1

    => (3) Extra indentation level found

Especially (2) was somewhat difficult for users to recognize what
is wrong, because a) indentation looks fine on text editor, b) but
Fluent Bit is still complaining.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>