### PR TITLE
fastcgi: fix size of length for name-value pairs

### DIFF
--- a/plugins/fastcgi/fcgi_handler.c
+++ b/plugins/fastcgi/fcgi_handler.c
@@ -52,7 +52,7 @@ static inline void fcgi_build_request_body(struct fcgi_begin_request_body *body)
 
 static inline size_t fcgi_write_length(char *p, size_t len)
 {
-    if (len < 127) {
+    if (len <= 127) {
 		*p++ = len;
 		return 1;
     }


### PR DESCRIPTION
The FastCGI spec say:
"Lengths of 127 bytes and less can be encoded in one byte,
while longer lengths are The problem here is that fcgi_write_length compute on 4 byte if size is
stricly less than 127.
But fcgi_add_param compute total length with size stricly above 127.