### PR TITLE
core: rconf: fixes incorrect skipping of configuration parse error

### DIFF
--- a/mk_core/mk_rconf.c
+++ b/mk_core/mk_rconf.c
@@ -340,6 +340,9 @@ static int mk_rconf_read(struct mk_rconf *conf, const char *path)
         if (strncmp(buf, indent, indent_len) != 0 ||
             isblank(buf[indent_len]) != 0) {
             mk_config_error(path, line, "Invalid indentation level");
+            mk_mem_free(key);
+            mk_mem_free(val);
+            return -1;
         }
 
         if (buf[indent_len] == '#' || indent_len == len) {


### PR DESCRIPTION
This PR tries to address the issue from https://github.com/fluent/fluent-bit/issues/3162
where the invalid configuration file will not populate a non-zero code:
```
$ cat fluent-bit.conf
[INPUT]
    Name cpu

[OUTPUT]
    Name stdout

NONSENSE NONSENSE NONSENSE
$ bin/fluent-bit -c fluent-bit.conf --dry-run
Fluent Bit v1.8.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/03/08 16:33:03] [  Error] File fluent-bit.conf
[2021/03/08 16:33:03] [  Error] Error in line 7: Invalid indentation level
configuration test is successful
$ echo $?
0
```
This PR fixes the issue and below is the new output:
```
$ bin/fluent-bit -c fluent-bit.conf --dry-run
Fluent Bit v1.8.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/03/08 16:31:48] [  Error] File fluent-bit.conf
[2021/03/08 16:31:48] [  Error] Error in line 7: Invalid indentation level
Error: Configuration file contains errors. Aborting

$ echo $?
1
```

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>