### PR TITLE
Compatibility fix for fluent-bit + Functionality fix in fifo channels

### DIFF
--- a/deps/regex/CMakeLists.txt
+++ b/deps/regex/CMakeLists.txt
@@ -1,7 +1,5 @@
-if(NOT DEFINED MK_HAVE_REGEX)
 set(src
     re.c
   )
 
 add_library(regex STATIC ${src})
-endif()

--- a/include/monkey/mk_core/external/winuio.h
+++ b/include/monkey/mk_core/external/winuio.h
@@ -14,7 +14,7 @@
 typedef SSIZE_T ssize_t;
 #endif
 
-struct iovec
+struct mk_iovec
 {
     void   *iov_base;    /* Base address of a memory region for input or output */
     size_t  iov_len;     /* The size of the memory pointed to by iov_base */
@@ -22,13 +22,13 @@ struct iovec
 
 /* Long way to go here, it's mostly a placeholder */
 
-static inline ssize_t readv(int fildes, const struct iovec *iov, int iovcnt)
+static inline ssize_t readv(int fildes, const struct mk_iovec *iov, int iovcnt)
 {
     errno = ENOSYS;
     return -1;
 }
 
-static inline ssize_t writev(int fildes, const struct iovec *iov, int iovcnt)
+static inline ssize_t writev(int fildes, const struct mk_iovec *iov, int iovcnt)
 {
     int i;
     uint32_t bytes_written = 0;

--- a/include/monkey/mk_core/mk_iov.h
+++ b/include/monkey/mk_core/mk_iov.h
@@ -50,7 +50,7 @@ struct mk_iov {
     int buf_idx;
     int size;
     unsigned long total_len;
-    struct iovec *io;
+    struct mk_iovec *io;
     void **buf_to_free;
 };
 

--- a/include/monkey/mk_core/mk_uio.h
+++ b/include/monkey/mk_core/mk_uio.h
@@ -5,6 +5,7 @@
 
 #ifdef MK_HAVE_SYS_UIO_H
 #include <sys/uio.h>
+typedef struct mk_iovec struct iovec;
 #else
 #include "external/winuio.h"
 #endif

--- a/include/monkey/mk_fifo.h
+++ b/include/monkey/mk_fifo.h
@@ -27,10 +27,20 @@
 
 #define MK_FIFO_BUF_SIZE   32768
 
+#ifdef _WIN32
+#ifdef _WIN64
+typedef long long mk_fifo_channel_fd;
+#else
+typedef long long mk_fifo_channel_fd;
+#endif
+#else
+typedef int mk_fifo_channel_fd;
+#endif
+
 struct mk_fifo_worker {
     struct mk_event event; /* event loop 'event' */
     int worker_id;         /* worker ID */
-    int channel[2];        /* pipe(2) communication channel */
+    mk_fifo_channel_fd channel[2];        /* pipe(2) communication channel */
     void *data;            /* opaque data for thread */
 
     /* Read buffer */

--- a/include/monkey/mk_http_internal.h
+++ b/include/monkey/mk_http_internal.h
@@ -74,7 +74,7 @@ struct response_headers
 
     /* IOV dirty hack */
     struct mk_iov headers_iov;
-    struct iovec __iov_io[MK_HEADER_IOV];
+    struct mk_iovec __iov_io[MK_HEADER_IOV];
     void *__iov_buf[MK_HEADER_IOV];
 };
 

--- a/mk_core/mk_iov.c
+++ b/mk_core/mk_iov.c
@@ -46,7 +46,7 @@ struct mk_iov *mk_iov_create(int n, int offset)
     struct mk_iov *iov;
 
     s_all      = sizeof(struct mk_iov);       /* main mk_iov structure */
-    s_iovec    = (n * sizeof(struct iovec));  /* iovec array size      */
+    s_iovec    = (n * sizeof(struct mk_iovec));  /* iovec array size      */
     s_free_buf = (n * sizeof(void *));        /* free buf array        */
 
     p = mk_mem_alloc_z(s_all + s_iovec + s_free_buf);
@@ -56,7 +56,7 @@ struct mk_iov *mk_iov_create(int n, int offset)
 
     /* Set pointer address */
     iov     = p;
-    iov->io = (uint8_t *)p + sizeof(struct mk_iov);
+    iov->io = (struct mk_iov *)((uint8_t *)p + sizeof(struct mk_iov));
     iov->buf_to_free = (void *) ((uint8_t*)p + sizeof(struct mk_iov) + s_iovec);
 
     mk_iov_init(iov, n, offset);
@@ -203,6 +203,6 @@ int mk_iov_consume(struct mk_iov *mk_io, size_t bytes)
         }
     }
 
-    mk_io->total_len -= bytes;
+    mk_io->total_len -= (unsigned long)bytes;
     return 0;
 }

--- a/mk_server/mk_fifo.c
+++ b/mk_server/mk_fifo.c
@@ -55,7 +55,7 @@ static struct mk_fifo_worker *mk_fifo_worker_create(struct mk_fifo *ctx,
     fw->buf_size = MK_FIFO_BUF_SIZE;
 
 #ifdef _WIN32
-    ret = evutil_socketpair(AF_UNIX, SOCK_STREAM, 0, fw->channel);
+    ret = evutil_socketpair(AF_INET, SOCK_STREAM, 0, fw->channel);
     if (ret == -1) {
         perror("socketpair");
         mk_mem_free(fw);

--- a/mk_server/mk_scheduler.c
+++ b/mk_server/mk_scheduler.c
@@ -829,7 +829,6 @@ int mk_sched_broadcast_signal(struct mk_server *server, uint64_t val)
 {
     int i;
     int count = 0;
-    ssize_t n;
     struct mk_sched_ctx *ctx;
     struct mk_sched_worker *worker;
 


### PR DESCRIPTION
mk_core : Changed the iovec structure definition name to mk_iovec to avoid issues with the definition made by msgpack (only when having to plug it in windows)

mk_fifo : Fixed a bug in the fifo channel array definition which was defined as a 2
 default size integer array (32 bits) which works for most platforms but libevent which defines the socket type as either a 32 bit int for 32 bit platforms or a 64 bit int for 64 bit platforms resulting in the second peer of the pipe pair being written outside of the array bounds causing both a memory corruption issue as well as a connectivity issue.

regex: Since the regex engine change was made on all platforms the regex engine compilation shouldn't be dependent of if the target platform does have a regex implementation or not