### PR TITLE
regex: engine symbol limit incremented

### DIFF
--- a/api/test.c
+++ b/api/test.c
@@ -18,6 +18,27 @@ void cb_worker(void *data)
     mk_info("[api test] test worker callback; data=%p", data);
 }
 
+
+void cb_sp_test_task_detail(mk_request_t *request, void *data)
+{
+    int i;
+    (void) data;
+
+    mk_http_status(request, 200);
+    mk_http_send(request, "CB_SP_TEST_TASK_DETAIL", strlen("CB_SP_TEST_TASK_DETAIL"), NULL);
+    mk_http_done(request);
+}
+
+void cb_sp_test_task_main(mk_request_t *request, void *data)
+{
+    int i;
+    (void) data;
+
+    mk_http_status(request, 200);
+    mk_http_send(request, "CB_SP_TEST_TASK_MAIN", strlen("CB_SP_TEST_TASK_MAIN"), NULL);
+    mk_http_done(request);
+}
+
 void cb_main(mk_request_t *request, void *data)
 {
     int i;
@@ -133,9 +154,17 @@ int main()
     mk_vhost_set(ctx, vid,
                  "Name", "monotop",
                  NULL);
+
+    mk_vhost_handler(ctx, vid, "/api/v1/stream_processor/task/[A-Za-z_][0-9A-Za-z_\\-]*", 
+                     cb_sp_test_task_detail, NULL);
+    
+    mk_vhost_handler(ctx, vid, "/api/v1/stream_processor/task",
+                     cb_sp_test_task_main, NULL);
+
     mk_vhost_handler(ctx, vid, "/test_chunks", cb_test_chunks, NULL);
     mk_vhost_handler(ctx, vid, "/test_big_chunk", cb_test_big_chunk, NULL);
     mk_vhost_handler(ctx, vid, "/", cb_main, NULL);
+
 
     mk_worker_callback(ctx,
                        cb_worker,

--- a/deps/regex/re.h
+++ b/deps/regex/re.h
@@ -43,8 +43,12 @@ extern "C"{
 
 /* Definitions: */
 
-#define MAX_REGEXP_OBJECTS      30    /* Max number of regex symbols in expression. */
-#define MAX_CHAR_CLASS_LEN      40    /* Max length of character-class buffer in.   */
+/* This was incremented because everything counts as a symbol, even literals and because
+ * of that the longer regular expressions matched wrong input text because they were only
+ * partially compiled
+ */
+#define MAX_REGEXP_OBJECTS      512    /* Max number of regex symbols in expression. */
+#define MAX_CHAR_CLASS_LEN      40     /* Max length of character-class buffer in.   */
 
 
 enum { UNUSED, DOT, BEGIN, END, QUESTIONMARK, STAR, PLUS, RE_CHAR, CHAR_CLASS, INV_CHAR_CLASS, DIGIT, NOT_DIGIT, ALPHA, NOT_ALPHA, WHITESPACE, NOT_WHITESPACE, /* BRANCH */ };


### PR DESCRIPTION
regex: incremented the symbol limit in the regex engine so it properly compiles longer expressions, otherwise it compiles the regex up to the symbol limit stopping there but not failing which causes false positives.

api_test: added two handlers to test the regex engine

TODO: refactor tinyregex so the regex structure is dynamically allocated making it flexible, less wasteful and more communicative (raising errors!)