### PR TITLE
Add `mk_vhost_destroy` function to release vhost

### DIFF
--- a/include/monkey/mk_lib.h
+++ b/include/monkey/mk_lib.h
@@ -48,7 +48,7 @@ MK_EXPORT mk_ctx_t *mk_create();
 MK_EXPORT int mk_destroy(mk_ctx_t *ctx);
 
 MK_EXPORT int mk_config_set(mk_ctx_t *ctx, ...);
-
+MK_EXPORT struct mk_vhost *mk_vhost_lookup(mk_ctx_t *ctx, int id);
 MK_EXPORT int mk_vhost_create(mk_ctx_t *ctx, char *name);
 
 MK_EXPORT int mk_vhost_set(mk_ctx_t *ctx, int vid, ...);

--- a/include/monkey/mk_vhost.h
+++ b/include/monkey/mk_vhost.h
@@ -119,5 +119,5 @@ struct mk_vhost_handler *mk_vhost_handler_match(char *match,
                                                 void (*cb)(struct mk_http_request *,
                                                            void *),
                                                 void *data);
-
+int mk_vhost_destroy(struct mk_vhost *vh);
 #endif

--- a/mk_server/mk_lib.c
+++ b/mk_server/mk_lib.c
@@ -376,7 +376,7 @@ int mk_config_set(mk_ctx_t *ctx, ...)
 }
 
 /* Given a vhost id, return the vhost context */
-static struct mk_vhost *mk_vhost_lookup(mk_ctx_t *ctx, int id)
+struct mk_vhost *mk_vhost_lookup(mk_ctx_t *ctx, int id)
 {
     struct mk_vhost *host;
     struct mk_list *head;


### PR DESCRIPTION
https://github.com/fluent/fluent-bit using monkey as a library and it uses vhost api.
We need to release vhost on exit service and I sent a patch to add the function to release vhost.
Note: https://github.com/fluent/fluent-bit/pull/3489

- expose `mk_vhost_lookup` to use from `mk_vhost_destroy`.
- add `mk_vhost_destroy(struct mk_vhost *)`
  -  The implementation is based `mk_vhost_free_all`. `mk_vhost_free_all` is to release vhost iteratively.
  - I moved the implementation from `mk_vhost_free_all`. (This diff is confusing, but It just be moved and add NULL checking)

## Valgrind output

This is an output of fluent-bit.
There is still leakage but some leaks caused by vhost are removed. https://github.com/fluent/fluent-bit/pull/3489#issue-645135979

```
$ valgrind --leak-check=full bin/fluent-bit -i cpu -o prometheus_exporter 
==20781== Memcheck, a memory error detector
==20781== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==20781== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==20781== Command: bin/fluent-bit -i cpu -o prometheus_exporter
==20781== 
Fluent Bit v1.8.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/05/16 15:21:31] [ info] [engine] started (pid=20781)
[2021/05/16 15:21:31] [ info] [storage] version=1.1.1, initializing...
[2021/05/16 15:21:31] [ info] [storage] in-memory
[2021/05/16 15:21:31] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/05/16 15:21:32] [ info] [output:prometheus_exporter:prometheus_exporter.0] listening iface=0.0.0.0 tcp_port=2021
[2021/05/16 15:21:32] [ info] [sp] stream processor started
==20781== Warning: client switching stacks?  SP change: 0x57e48b8 --> 0x4c78970
==20781==          to suppress, use: --max-stackframe=11976520 or greater
==20781== Warning: client switching stacks?  SP change: 0x4c788e8 --> 0x57e48b8
==20781==          to suppress, use: --max-stackframe=11976656 or greater
==20781== Warning: client switching stacks?  SP change: 0x57e48b8 --> 0x4c788e8
==20781==          to suppress, use: --max-stackframe=11976656 or greater
==20781==          further instances of this message will not be shown.
^C[2021/05/16 15:21:36] [engine] caught signal (SIGINT)
[2021/05/16 15:21:36] [ info] [input] pausing cpu.0
[2021/05/16 15:21:36] [ warn] [engine] service will stop in 5 seconds
[2021/05/16 15:21:41] [ info] [engine] service stopped
==20781== 
==20781== HEAP SUMMARY:
==20781==     in use at exit: 19,948 bytes in 42 blocks
==20781==   total heap usage: 343 allocs, 301 frees, 1,005,298 bytes allocated
==20781== 
==20781== 40 bytes in 1 blocks are possibly lost in loss record 21 of 42
==20781==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==20781==    by 0x23543D: flb_malloc (flb_mem.h:62)
==20781==    by 0x235673: cb_mq_metrics (prom_http.c:105)
==20781==    by 0x4878F6: mk_fifo_worker_read (mk_fifo.c:431)
==20781==    by 0x4972EC: mk_server_worker_loop (mk_server.c:569)
==20781==    by 0x48DE74: mk_sched_launch_worker_loop (mk_scheduler.c:418)
==20781==    by 0x4864608: start_thread (pthread_create.c:477)
==20781==    by 0x4B10292: clone (clone.S:95)
==20781== 
==20781== 125 bytes in 1 blocks are possibly lost in loss record 29 of 42
==20781==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==20781==    by 0x23543D: flb_malloc (flb_mem.h:62)
==20781==    by 0x2356B3: cb_mq_metrics (prom_http.c:111)
==20781==    by 0x4878F6: mk_fifo_worker_read (mk_fifo.c:431)
==20781==    by 0x4972EC: mk_server_worker_loop (mk_server.c:569)
==20781==    by 0x48DE74: mk_sched_launch_worker_loop (mk_scheduler.c:418)
==20781==    by 0x4864608: start_thread (pthread_create.c:477)
==20781==    by 0x4B10292: clone (clone.S:95)
==20781== 
==20781== 288 bytes in 1 blocks are possibly lost in loss record 34 of 42
==20781==    at 0x483DD99: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==20781==    by 0x4014B1A: allocate_dtv (dl-tls.c:343)
==20781==    by 0x4014B1A: _dl_allocate_tls (dl-tls.c:589)
==20781==    by 0x4865322: allocate_stack (allocatestack.c:622)
==20781==    by 0x4865322: pthread_create@@GLIBC_2.2.5 (pthread_create.c:660)
==20781==    by 0x49E510: mk_utils_worker_spawn (mk_utils.c:284)
==20781==    by 0x4857F5: mk_start (mk_lib.c:184)
==20781==    by 0x235AE6: prom_http_server_start (prom_http.c:238)
==20781==    by 0x23518E: cb_prom_init (prom.c:57)
==20781==    by 0x176F91: flb_output_init_all (flb_output.c:939)
==20781==    by 0x183A4F: flb_engine_start (flb_engine.c:520)
==20781==    by 0x16893B: flb_lib_worker (flb_lib.c:605)
==20781==    by 0x4864608: start_thread (pthread_create.c:477)
==20781==    by 0x4B10292: clone (clone.S:95)
==20781== 
==20781== 288 bytes in 1 blocks are possibly lost in loss record 35 of 42
==20781==    at 0x483DD99: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==20781==    by 0x4014B1A: allocate_dtv (dl-tls.c:343)
==20781==    by 0x4014B1A: _dl_allocate_tls (dl-tls.c:589)
==20781==    by 0x4865322: allocate_stack (allocatestack.c:622)
==20781==    by 0x4865322: pthread_create@@GLIBC_2.2.5 (pthread_create.c:660)
==20781==    by 0x49E510: mk_utils_worker_spawn (mk_utils.c:284)
==20781==    by 0x4999F9: mk_server_setup (monkey.c:180)
==20781==    by 0x485688: mk_lib_worker (mk_lib.c:142)
==20781==    by 0x4864608: start_thread (pthread_create.c:477)
==20781==    by 0x4B10292: clone (clone.S:95)
==20781== 
==20781== 288 bytes in 1 blocks are possibly lost in loss record 36 of 42
==20781==    at 0x483DD99: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==20781==    by 0x4014B1A: allocate_dtv (dl-tls.c:343)
==20781==    by 0x4014B1A: _dl_allocate_tls (dl-tls.c:589)
==20781==    by 0x4865322: allocate_stack (allocatestack.c:622)
==20781==    by 0x4865322: pthread_create@@GLIBC_2.2.5 (pthread_create.c:660)
==20781==    by 0x48DF1C: mk_sched_launch_thread (mk_scheduler.c:444)
==20781==    by 0x496B53: mk_server_launch_workers (mk_server.c:279)
==20781==    by 0x499A37: mk_server_setup (monkey.c:196)
==20781==    by 0x485688: mk_lib_worker (mk_lib.c:142)
==20781==    by 0x4864608: start_thread (pthread_create.c:477)
==20781==    by 0x4B10292: clone (clone.S:95)
==20781== 
==20781== LEAK SUMMARY:
==20781==    definitely lost: 0 bytes in 0 blocks
==20781==    indirectly lost: 0 bytes in 0 blocks
==20781==      possibly lost: 1,029 bytes in 5 blocks
==20781==    still reachable: 18,919 bytes in 37 blocks
==20781==         suppressed: 0 bytes in 0 blocks
==20781== Reachable blocks (those to which a pointer was found) are not shown.
==20781== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==20781== 
==20781== For lists of detected and suppressed errors, rerun with: -s
==20781== ERROR SUMMARY: 5 errors from 5 contexts (suppressed: 0 from 0)
```