### PR TITLE
flb_libco: Add support to build on Apple Silicon

### DIFF
--- a/deps/flb_libco/CMakeLists.txt
+++ b/deps/flb_libco/CMakeLists.txt
@@ -2,5 +2,13 @@ set(src
   libco.c
   )
 
+# Check for posix_memalign so that Apple Silicon can be supported
+include(CheckSymbolExists)
+check_symbol_exists(posix_memalign "stdlib.h" HAVE_POSIX_MEMALIGN)
+IF(HAVE_POSIX_MEMALIGN)
+  add_definitions(-DHAVE_POSIX_MEMALIGN)
+  MESSAGE("Found posix_memalign setting -DHAVE_POSIX_MEMALIGN")
+ENDIF(HAVE_POSIX_MEMALIGN)
+
 add_definitions(-DLIBCO_MP)
 add_library(co STATIC ${src})

--- a/deps/flb_libco/aarch64.c
+++ b/deps/flb_libco/aarch64.c
@@ -12,8 +12,10 @@
 #include <string.h>
 #include <stdint.h>
 
+#ifndef __APPLE__
 #ifndef IOS
 #include <malloc.h>
+#endif
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
Add a check for posix_memalign in stdlib.h as this wasn't detected on M1 causing a _memalign missing symbol
Do not include malloc.h if __APPLE__ is defined