### PR TITLE
core: broadcast FREE_ALL signal on exit(#342)

### DIFF
--- a/mk_server/monkey.c
+++ b/mk_server/monkey.c
@@ -212,7 +212,7 @@ void mk_exit_all(struct mk_server *server)
 
     /* Distribute worker signals to stop working */
     val = MK_SCHED_SIGNAL_FREE_ALL;
-    mk_sched_send_signal(server, val);
+    mk_sched_broadcast_signal(server, val);
 
     /* Wait for all workers to finish */
     mk_sched_workers_join(server);


### PR DESCRIPTION
Fixes #342.

We should send MK_SCHED_SIGNAL_FREE_ALL signal  to workers.
I modified to use mk_sched_broadcast_signal for broadcasting.