### PR TITLE
Fix compiler warnings

### DIFF
--- a/api/test.c
+++ b/api/test.c
@@ -21,7 +21,6 @@ void cb_worker(void *data)
 
 void cb_sp_test_task_detail(mk_request_t *request, void *data)
 {
-    int i;
     (void) data;
 
     mk_http_status(request, 200);
@@ -31,7 +30,6 @@ void cb_sp_test_task_detail(mk_request_t *request, void *data)
 
 void cb_sp_test_task_main(mk_request_t *request, void *data)
 {
-    int i;
     (void) data;
 
     mk_http_status(request, 200);

--- a/mk_core/mk_iov.c
+++ b/mk_core/mk_iov.c
@@ -57,7 +57,7 @@ struct mk_iov *mk_iov_create(int n, int offset)
 
     /* Set pointer address */
     iov     = p;
-    iov->io = (struct mk_iov *)((uint8_t *)p + sizeof(struct mk_iov));
+    iov->io = (struct mk_iovec *)((uint8_t *)p + sizeof(struct mk_iov));
     iov->buf_to_free = (void *) ((uint8_t*)p + sizeof(struct mk_iov) + s_iovec);
 
     mk_iov_init(iov, n, offset);

--- a/plugins/cgi/cgi.c
+++ b/plugins/cgi/cgi.c
@@ -18,6 +18,7 @@
  *  limitations under the License.
  */
 
+#include <monkey/mk_stream.h>
 #include "cgi.h"
 
 #include <sys/types.h>
@@ -78,7 +79,7 @@ int channel_write(struct cgi_request *r, void *buf, size_t count)
     }
 
     MK_TRACE("channel write: %d bytes", count);
-    mk_stream_in_cbuf(&r->sr->stream,
+    mk_stream_in_raw(&r->sr->stream,
                       NULL,
                       buf, count,
                       NULL, NULL);

--- a/plugins/dirlisting/dirlisting.c
+++ b/plugins/dirlisting/dirlisting.c
@@ -27,6 +27,7 @@
  */
 
 #include <monkey/mk_api.h>
+#include <monkey/mk_stream.h>
 #include "dirlisting.h"
 
 #include <time.h>
@@ -664,7 +665,7 @@ void mk_dirhtml_cb_body_rows(struct mk_stream_input *in)
         if (req->chunked) {
             len = snprintf(tmp, sizeof(tmp), "%x\r\n",
                            (int) req->iov_footer->total_len);
-            mk_stream_in_cbuf(req->stream,
+            mk_stream_in_raw(req->stream,
                               NULL,
                               tmp, len,
                               NULL, NULL);
@@ -679,7 +680,7 @@ void mk_dirhtml_cb_body_rows(struct mk_stream_input *in)
                          req->iov_footer,
                          NULL, NULL);
         if (req->chunked) {
-            mk_stream_in_cbuf(req->stream,
+            mk_stream_in_raw(req->stream,
                               NULL,
                               "\r\n0\r\n\r\n", 7,
                               NULL, mk_dirhtml_cb_complete);
@@ -692,7 +693,7 @@ void mk_dirhtml_cb_body_rows(struct mk_stream_input *in)
     if (req->chunked) {
         len = snprintf(tmp, sizeof(tmp), "%x\r\n",
                        (int) req->iov_entry->total_len);
-        mk_stream_in_cbuf(req->stream,
+        mk_stream_in_raw(req->stream,
                           NULL,
                           tmp, len,
                           NULL, NULL);
@@ -708,7 +709,7 @@ void mk_dirhtml_cb_body_rows(struct mk_stream_input *in)
                      NULL, cb_ok);
 
     if (req->chunked) {
-        mk_stream_in_cbuf(req->stream,
+        mk_stream_in_raw(req->stream,
                           NULL,
                           "\r\n", 2,
                           mk_dirhtml_cb_chunk_body_rows, NULL);
@@ -839,7 +840,7 @@ static int mk_dirhtml_init(struct mk_plugin *plugin,
     if (request->chunked) {
         len = snprintf(tmp, sizeof(tmp), "%x\r\n",
                        (int) request->iov_header->total_len);
-        mk_stream_in_cbuf(request->stream,
+        mk_stream_in_raw(request->stream,
                           NULL,
                           tmp, len,
                           NULL, mk_dirhtml_cb_complete);
@@ -851,7 +852,7 @@ static int mk_dirhtml_init(struct mk_plugin *plugin,
                      NULL, cb_header_finish);
 
     if (request->chunked) {
-        mk_stream_in_cbuf(request->stream,
+        mk_stream_in_raw(request->stream,
                           NULL,
                           "\r\n", 2,
                           NULL, NULL);

--- a/plugins/fastcgi/fcgi_handler.c
+++ b/plugins/fastcgi/fcgi_handler.c
@@ -19,6 +19,7 @@
 
 #include <monkey/mk_api.h>
 #include <monkey/mk_net.h>
+#include <monkey/mk_stream.h>
 
 #include "fastcgi.h"
 #include "fcgi_handler.h"
@@ -525,13 +526,13 @@ static char *getearliestbreak(const char buf[], const unsigned bufsize,
 
 static int fcgi_write(struct fcgi_handler *handler, char *buf, size_t len)
 {
-    mk_stream_in_cbuf(handler->stream,
+    mk_stream_in_raw(handler->stream,
                       NULL,
                       buf, len,
                       NULL, NULL);
 
     if (handler->headers_set == MK_TRUE) {
-        mk_stream_in_cbuf(handler->stream,
+        mk_stream_in_raw(handler->stream,
                           NULL,
                           "\r\n", 2,
                           NULL, NULL);
@@ -622,7 +623,7 @@ static int fcgi_response(struct fcgi_handler *handler, char *buf, size_t len)
 
     if (len == 0 && handler->chunked && handler->headers_set == MK_TRUE) {
         MK_TRACE("[fastcgi=%i] sending EOF", handler->server_fd);
-        mk_stream_in_cbuf(handler->stream,
+        mk_stream_in_raw(handler->stream,
                           NULL,
                           "0\r\n\r\n", 5,
                           NULL, NULL);
@@ -672,7 +673,7 @@ static int fcgi_response(struct fcgi_handler *handler, char *buf, size_t len)
 
     if (p_len > 0) {
         xlen = snprintf(tmp, 16, "%x\r\n", (unsigned int) p_len);
-        mk_stream_in_cbuf(handler->stream,
+        mk_stream_in_raw(handler->stream,
                           NULL,
                           tmp, xlen,
                           NULL, NULL);

--- a/plugins/liana/liana.c
+++ b/plugins/liana/liana.c
@@ -86,9 +86,6 @@ int mk_liana_close(int socket_fd)
 int mk_liana_send_file(int socket_fd, int file_fd, off_t *file_offset,
                        size_t file_count)
 {
-    ssize_t bytes_written = 0;
-    ssize_t to_be_sent = -1;
-    ssize_t send_ret = -1;
     ssize_t ret = -1;
 
 #if defined (__linux__)
@@ -129,6 +126,9 @@ int mk_liana_send_file(int socket_fd, int file_fd, off_t *file_offset,
 #else
     #pragma message ("This is a terrible sendfile \"implementation\" and just a crutch")
 
+    ssize_t bytes_written = 0;
+    ssize_t to_be_sent = -1;
+    ssize_t send_ret = -1;
     uint8_t temporary_buffer[1024];
 
     if (NULL != file_offset) {


### PR DESCRIPTION
Resolve various compiler warnings:
1. unused variables
2. incompatible pointer assignment
3. implicit function declaration

Fixes #344 (I think).

cc @edsiper 