### PR TITLE
core: event: fixed out of bounds memory read

### DIFF
--- a/include/monkey/mk_core/mk_event_epoll.h
+++ b/include/monkey/mk_core/mk_event_epoll.h
@@ -28,17 +28,17 @@ struct mk_event_ctx {
     struct epoll_event *events;
 };
 
-#define mk_event_foreach(event, evl)                                    \
-    int __i;                                                            \
-    struct mk_event_ctx *__ctx = evl->data;                             \
-                                                                        \
-    if (evl->n_events > 0) {                                            \
-        event = __ctx->events[0].data.ptr;                              \
-    }                                                                   \
-                                                                        \
-    for (__i = 0;                                                       \
-         __i < evl->n_events;                                           \
-         __i++,                                                         \
-             event = __ctx->events[__i].data.ptr                        \
+#define mk_event_foreach(event, evl)                                              \
+    int __i;                                                                      \
+    struct mk_event_ctx *__ctx = evl->data;                                       \
+                                                                                  \
+    if (evl->n_events > 0) {                                                      \
+        event = __ctx->events[0].data.ptr;                                        \
+    }                                                                             \
+                                                                                  \
+    for (__i = 0;                                                                 \
+         __i < evl->n_events;                                                     \
+         __i++,                                                                   \
+             event = ((__i < evl->n_events) ? __ctx->events[__i].data.ptr : NULL) \
          )
 #endif

--- a/include/monkey/mk_core/mk_event_kqueue.h
+++ b/include/monkey/mk_core/mk_event_kqueue.h
@@ -56,17 +56,17 @@ static inline int filter_mask(int16_t f)
 }
 
 
-#define mk_event_foreach(event, evl)                                    \
-    int __i;                                                            \
-    struct mk_event_ctx *__ctx = evl->data;                             \
-                                                                        \
-    if (evl->n_events > 0) {                                            \
-        event = __ctx->events[0].udata;                                 \
-    }                                                                   \
-                                                                        \
-    for (__i = 0;                                                       \
-         __i < evl->n_events;                                           \
-         __i++,                                                         \
-             event = __ctx->events[__i].udata                           \
+#define mk_event_foreach(event, evl)                                           \
+    int __i;                                                                   \
+    struct mk_event_ctx *__ctx = evl->data;                                    \
+                                                                               \
+    if (evl->n_events > 0) {                                                   \
+        event = __ctx->events[0].udata;                                        \
+    }                                                                          \
+                                                                               \
+    for (__i = 0;                                                              \
+         __i < evl->n_events;                                                  \
+         __i++,                                                                \
+             event = ((__i < evl->n_events) ? __ctx->events[__i].udata : NULL) \
          )
 #endif

--- a/include/monkey/mk_core/mk_event_libevent.h
+++ b/include/monkey/mk_core/mk_event_libevent.h
@@ -29,17 +29,17 @@ struct mk_event_ctx {
     struct mk_event *fired;    /* used to create iteration array    */
 };
 
-#define mk_event_foreach(event, evl)                                    \
-    int __i;                                                            \
-    struct mk_event_ctx *__ctx = evl->data;                             \
-                                                                        \
-    if (evl->n_events > 0) {                                            \
-        event = __ctx->fired[0].data;                                   \
-    }                                                                   \
-                                                                        \
-    for (__i = 0;                                                       \
-         __i < evl->n_events;                                           \
-         __i++,                                                         \
-             event = __ctx->fired[__i].data                             \
+#define mk_event_foreach(event, evl)                                         \
+    int __i;                                                                 \
+    struct mk_event_ctx *__ctx = evl->data;                                  \
+                                                                             \
+    if (evl->n_events > 0) {                                                 \
+        event = __ctx->fired[0].data;                                        \
+    }                                                                        \
+                                                                             \
+    for (__i = 0;                                                            \
+         __i < evl->n_events;                                                \
+         __i++,                                                              \
+             event = ((__i < evl->n_events) ? __ctx->fired[__i].data : NULL) \
          )
 #endif

--- a/include/monkey/mk_core/mk_event_select.h
+++ b/include/monkey/mk_core/mk_event_select.h
@@ -42,18 +42,18 @@ struct mk_event_ctx {
     struct mk_event *fired;    /* used to create iteration array    */
 };
 
-#define mk_event_foreach(event, evl)                                    \
-    int __i;                                                            \
-    struct mk_event_ctx *__ctx = evl->data;                             \
-                                                                        \
-    if (evl->n_events > 0) {                                            \
-        event = __ctx->fired[0].data;                                   \
-    }                                                                   \
-                                                                        \
-    for (__i = 0;                                                       \
-         __i < evl->n_events;                                           \
-         __i++,                                                         \
-             event = __ctx->fired[__i].data                             \
+#define mk_event_foreach(event, evl)                                         \
+    int __i;                                                                 \
+    struct mk_event_ctx *__ctx = evl->data;                                  \
+                                                                             \
+    if (evl->n_events > 0) {                                                 \
+        event = __ctx->fired[0].data;                                        \
+    }                                                                        \
+                                                                             \
+    for (__i = 0;                                                            \
+         __i < evl->n_events;                                                \
+         __i++,                                                              \
+             event = ((__i < evl->n_events) ? __ctx->fired[__i].data : NULL) \
          )
 
 #endif


### PR DESCRIPTION
Out of bounds read when evl->n_events is equal to the number of event slots the event loop was initialized with.

This out of bounds read should not cause any issues itself unless the mk_event_ctx structure is perfectly aligned at the end of the page with no contiguously mapped page or with a mapped page that lacks the PROT_READ protection mode in which case it would cause a segmentation fault.