### PR TITLE
core: event: introduce mk_event_timeout_disable() function

### DIFF
--- a/include/monkey/mk_core/mk_event.h
+++ b/include/monkey/mk_core/mk_event.h
@@ -131,6 +131,7 @@ int mk_event_add(struct mk_event_loop *loop, int fd,
 int mk_event_del(struct mk_event_loop *loop, struct mk_event *event);
 int mk_event_timeout_create(struct mk_event_loop *loop,
                             time_t sec, long nsec,void *data);
+int mk_event_timeout_disable(struct mk_event_loop *loop, void *data);
 int mk_event_timeout_destroy(struct mk_event_loop *loop, void *data);
 int mk_event_channel_create(struct mk_event_loop *loop,
                             int *r_fd, int *w_fd, void *data);

--- a/mk_core/mk_event.c
+++ b/mk_core/mk_event.c
@@ -136,6 +136,12 @@ int mk_event_timeout_create(struct mk_event_loop *loop,
     return _mk_event_timeout_create(ctx, sec, nsec, data);
 }
 
+/* Disable timer */
+int mk_event_timeout_disable(struct mk_event_loop *loop, void *data)
+{
+    return mk_event_del(loop, (struct mk_event *) data);
+}
+
 /* Destroy timer */
 int mk_event_timeout_destroy(struct mk_event_loop *loop, void *data)
 {

--- a/mk_core/mk_event_epoll.c
+++ b/mk_core/mk_event_epoll.c
@@ -146,6 +146,10 @@ static inline int _mk_event_del(struct mk_event_ctx *ctx, struct mk_event *event
 {
     int ret;
 
+    if ((event->status & MK_EVENT_REGISTERED) == 0) {
+        return 0;
+    }
+
     ret = epoll_ctl(ctx->efd, EPOLL_CTL_DEL, event->fd, NULL);
     MK_TRACE("[FD %i] Epoll, remove from QUEUE_FD=%i, ret=%i",
              event->fd, ctx->efd, ret);
@@ -154,6 +158,8 @@ static inline int _mk_event_del(struct mk_event_ctx *ctx, struct mk_event *event
         mk_libc_warn("epoll_ctl");
 #endif
     }
+
+    MK_EVENT_NEW(event);
 
     return ret;
 }

--- a/mk_core/mk_event_kqueue.c
+++ b/mk_core/mk_event_kqueue.c
@@ -137,6 +137,10 @@ static inline int _mk_event_del(struct mk_event_ctx *ctx, struct mk_event *event
     int ret;
     struct kevent ke = {0, 0, 0, 0, 0, 0};
 
+    if ((event->status & MK_EVENT_REGISTERED) == 0) {
+        return 0;
+    }
+
     if (event->mask & MK_EVENT_READ) {
         EV_SET(&ke, event->fd, EVFILT_READ, EV_DELETE, 0, 0, NULL);
         ret = kevent(ctx->kfd, &ke, 1, NULL, 0, NULL);
@@ -154,6 +158,8 @@ static inline int _mk_event_del(struct mk_event_ctx *ctx, struct mk_event *event
             return ret;
         }
     }
+
+    MK_EVENT_NEW(event);
 
     return 0;
 }

--- a/mk_core/mk_event_libevent.c
+++ b/mk_core/mk_event_libevent.c
@@ -212,6 +212,10 @@ static inline int _mk_event_del(struct mk_event_ctx *ctx, struct mk_event *event
     int ret;
     struct ev_map *ev_map;
 
+    if ((event->status & MK_EVENT_REGISTERED) == 0) {
+        return 0;
+    }
+
     ev_map = event->data;
     if (ev_map->pipe[0] > 0) {
         evutil_closesocket(ev_map->pipe[0]);
@@ -223,6 +227,8 @@ static inline int _mk_event_del(struct mk_event_ctx *ctx, struct mk_event *event
     ret = event_del(ev_map->event);
     event_free(ev_map->event);
     mk_mem_free(ev_map);
+
+    MK_EVENT_NEW(event);
 
     return ret;
 }

--- a/mk_core/mk_event_select.c
+++ b/mk_core/mk_event_select.c
@@ -122,6 +122,10 @@ static inline int _mk_event_del(struct mk_event_ctx *ctx, struct mk_event *event
     int fd;
     struct mk_event *s_event;
 
+    if ((event->status & MK_EVENT_REGISTERED) == 0) {
+        return 0;
+    }
+
     fd = event->fd;
 
     if (event->mask & MK_EVENT_READ) {
@@ -148,6 +152,9 @@ static inline int _mk_event_del(struct mk_event_ctx *ctx, struct mk_event *event
     }
 
     ctx->events[fd] = NULL;
+
+    MK_EVENT_NEW(event);
+
     return 0;
 }
 


### PR DESCRIPTION
This pull request adds the mk_event_timeout_disable function meant to remove a timer from the event loop thus properly preventing any non timely timer ticks from generating events.