### PR TITLE
core: added rudimentary initialization check on mk_http_error

### DIFF
--- a/mk_server/mk_http.c
+++ b/mk_server/mk_http.c
@@ -1213,6 +1213,14 @@ int mk_http_error(int http_status, struct mk_http_session *cs,
     struct file_info finfo;
     struct mk_iov *iov;
 
+    /* This function requires monkey to be properly initialized which is not the case
+     * when it's just used to parse http requests in fluent-bit so we want it to ignore
+     * that case and let fluent-bit handle it.
+    */
+    if (server->workers == 0) {
+        return MK_EXIT_OK;
+    }
+
     mk_header_set_http_status(sr, http_status);
     mk_ptr_reset(&page);
 


### PR DESCRIPTION
This PR adds a simple initialization check to the mk_http_error function so when it's 
called from mk_http_parser when fluent-bit is trying to process a user request in the
in_http plugin which does not initialize the monkey server (at all) it does not try to
deliver the error message itself but rather leave it to the caller.

This could also be implemented by adding an explicit initialization flag to the mk_server 
structure, in this case we rely on the fact that we know that if workers is zero it has not
been initialized.

Signed-off-by: Leonardo Alminana <leonardo@calyptia.com>