### PR TITLE
mkcore: resolve monkey indentation sentinel termination error

### DIFF
--- a/mk_core/mk_rconf.c
+++ b/mk_core/mk_rconf.c
@@ -364,8 +364,6 @@ static int mk_rconf_read(struct mk_rconf *conf, const char *path)
         /* Validate indentation level */
         if (check_indent(buf, indent) < 0) {
             mk_config_error(path, line, "Invalid indentation level");
-            mk_mem_free(key);
-            mk_mem_free(val);
             return -1;
         }
 


### PR DESCRIPTION
Signed-off-by: Matthew Fala <falamatt@amazon.com>

<!-- Provide summary of changes -->

## Monkey Sentinel Error
On exiting a program due to invalid indentation, monkey throws a malloc free error.

![Screen Shot 2021-09-24 at 4 15 13 PM](https://user-images.githubusercontent.com/34408404/134748762-a552f9c4-5e05-47a9-87bb-da1a0ca6f259.png)

It appears key and value are freed before they are allocated, causing this error.
![Screen Shot 2021-09-24 at 4 21 59 PM](https://user-images.githubusercontent.com/34408404/134748818-6308a142-3c11-46f2-8b88-fe6e7715eccd.png)

Deleting the unnecessary frees resolves the problem
 
![Screen Shot 2021-09-24 at 4 13 27 PM](https://user-images.githubusercontent.com/34408404/134748860-7cc10ace-c408-4523-8799-62edcb26a35c.png)

This is really an upstream monkey error: https://github.com/monkey/monkey/blob/master/mk_core/mk_rconf.c#L366 .
Please feel free to reject this PR and resolve in Monkey if that would be standard procedure.


Config file causing malloc free error:
```
[SERVICE]
     Grace 30
     Log_Level debug

# Provide entry point for logs
[INPUT]
   Name http
     host 0.0.0.0
     port 8888

[OUTPUT]
     Name stdout
     Match *
```

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X ] Example configuration file for the change
- [ X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature
