### PR TITLE
core: Fix abosolute glob

### DIFF
--- a/mk_core/mk_rconf.c
+++ b/mk_core/mk_rconf.c
@@ -469,16 +469,16 @@ static int mk_rconf_read_glob(struct mk_rconf *conf, const char * path)
     if (ret_glb != 0) {
         switch(ret_glb){
         case GLOB_NOSPACE:
-            mk_warn("[%s] glob: no space", __FUNCTION__);
+            mk_warn("[%s] glob: [%s] no space", __FUNCTION__, glb_path);
             break;
         case GLOB_NOMATCH:
-            mk_warn("[%s] glob: no match", __FUNCTION__);
+            mk_warn("[%s] glob: [%s] no match", __FUNCTION__, glb_path);
             break;
         case GLOB_ABORTED:
-            mk_warn("[%s] glob: aborted", __FUNCTION__);
+            mk_warn("[%s] glob: [%s] aborted", __FUNCTION__, glb_path);
             break;
         default:
-            mk_warn("[%s] glob: other error", __FUNCTION__);
+            mk_warn("[%s] glob: [%s] other error", __FUNCTION__, glb_path);
         }
         return ret;
     }

--- a/mk_core/mk_rconf.c
+++ b/mk_core/mk_rconf.c
@@ -457,7 +457,7 @@ static int mk_rconf_read_glob(struct mk_rconf *conf, const char * path)
     size_t i;
     int ret_glb = -1;
 
-    if (conf->root_path) {
+    if (conf->root_path && path[0] != '/') {
         snprintf(tmp, PATH_MAX, "%s/%s", conf->root_path, path);
         glb_path = tmp;
     }


### PR DESCRIPTION
## Bug

fixes https://github.com/fluent/fluent-bit/issues/1294

Currently, using `@INCLUDE` with glob + absolute path fails with "glob: no match".

## Example
These fail with an error.
```
# NG
@INCLUDE /fluent-bit/etc/test/*.conf
@INCLUDE /fluent-bit/../fluent-bit/etc/test/*.conf
@INCLUDE /fluent-bit/*/*/*.conf
```

Glob with relative path or absolute path without glob works.
```
# OK
@INCLUDE /fluent-bit/etc/test/test.conf
@INCLUDE test/test.conf
@INCLUDE /fluent-bit/../fluent-bit/etc/test/test.conf
@INCLUDE ../etc/test/test.conf
@INCLUDE ../etc/test/*.conf
@INCLUDE test/*.conf
@INCLUDE **/*.conf
```

## Description

It is not working because even absolute path is passed, `conf->root_path` is concatenated for `glb_path`.
This PR handles absolute path with glob as is.

Also, adds a more helpful warning message.

## Testing

Tested with various `@INCLUDE` s here https://github.com/rajyan/fluent-bit-docker-image/pull/1

 
