### PR TITLE
core: windows shutdown issue corrections

### DIFF
--- a/mk_server/mk_clock.c
+++ b/mk_server/mk_clock.c
@@ -119,6 +119,7 @@ void *mk_clock_worker_init(void *data)
 
     mk_utils_worker_rename("monkey: clock");
     pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL);
+    pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS, NULL);
 
     mk_clock_tid = pthread_self();
 

--- a/mk_server/mk_fifo.c
+++ b/mk_server/mk_fifo.c
@@ -247,8 +247,14 @@ static int mk_fifo_worker_destroy_all(struct mk_fifo *ctx)
 
     mk_list_foreach_safe(head, tmp, &ctx->workers) {
         fw = mk_list_entry(head, struct mk_fifo_worker, _head);
+
+#ifdef _WIN32
+        evutil_closesocket(fw->channel[0]);
+        evutil_closesocket(fw->channel[1]);
+#else
         close(fw->channel[0]);
         close(fw->channel[1]);
+#endif
         mk_list_del(&fw->_head);
         mk_mem_free(fw->buf_data);
         mk_mem_free(fw);


### PR DESCRIPTION
This PR makes a few changes required for monkey to be able to terminate when requested : 

1. Makes the clock thread immediately cancellable (this could be a quirk in winpthreads)
2. Makes mk_server_loop_balancer monitor the management channel waiting for a termination request (otherwise it's an infinite loop)
3. Fixes incompatible IO api usage in a few places (in windows we're using libevent which uses sockets for pipes which means we can't use read/write and we have to use recv/send and it also affects the fd close function)

Notes: The ifdef blocks for these IO functions aren't elegant to say the least so a future PR will abstract that and hopefully the data type used for socket file descriptors because libevent represents sockets as intptr_t which is 64 bits wide in x64.