### PR TITLE
list: fix add_after prev pointer reference bug

### DIFF
--- a/include/monkey/mk_core/mk_list.h
+++ b/include/monkey/mk_core/mk_list.h
@@ -76,10 +76,10 @@ static inline void mk_list_add_after(struct mk_list *_new,
     }
 
     next = prev->next;
-    next->prev = prev;
     _new->next = next;
     _new->prev = prev;
     prev->next = _new;
+    next->prev = _new;
 }
 
 static inline void __mk_list_del(struct mk_list *prev, struct mk_list *next)


### PR DESCRIPTION
Signed-off-by: Matthew Fala <falamatt@amazon.com>

It seems that there is a reference bug in the mk_list_add_after() function which is used in mk_header.c.

### Old
```
+--------+--------+
| prev =>|<= next |
+--------+--------+
+--------+--------+-------+
| prev =>|<=_new=>| * next|
+---|----+--------+-|-----+
    ^---------------<  (broken reference) 
```

### Resolved
```
+--------+--------+-------+
| prev =>|<=_new=>|<=next |
+--------+--------+-------+
```