### PR TITLE
server: channel: added cleanup routine

### DIFF
--- a/include/monkey/mk_stream.h
+++ b/include/monkey/mk_stream.h
@@ -390,6 +390,7 @@ struct mk_stream *mk_stream_new(int type, struct mk_channel *channel,
 int mk_channel_stream_write(struct mk_stream *stream, size_t *count);
 
 struct mk_channel *mk_channel_new(int type, int fd);
+int mk_channel_release(mk_channel *channel);
 
 int mk_channel_flush(struct mk_channel *channel);
 int mk_channel_write(struct mk_channel *channel, size_t *count);

--- a/include/monkey/mk_stream.h
+++ b/include/monkey/mk_stream.h
@@ -390,7 +390,7 @@ struct mk_stream *mk_stream_new(int type, struct mk_channel *channel,
 int mk_channel_stream_write(struct mk_stream *stream, size_t *count);
 
 struct mk_channel *mk_channel_new(int type, int fd);
-int mk_channel_release(mk_channel *channel);
+int mk_channel_release(struct mk_channel *channel);
 
 int mk_channel_flush(struct mk_channel *channel);
 int mk_channel_write(struct mk_channel *channel, size_t *count);

--- a/mk_server/mk_stream.c
+++ b/mk_server/mk_stream.c
@@ -35,7 +35,7 @@ struct mk_channel *mk_channel_new(int type, int fd)
     return channel;
 }
 
-int mk_channel_release(mk_channel *channel)
+int mk_channel_release(struct mk_channel *channel)
 {
     mk_mem_free(channel);
 }

--- a/mk_server/mk_stream.c
+++ b/mk_server/mk_stream.c
@@ -35,6 +35,11 @@ struct mk_channel *mk_channel_new(int type, int fd)
     return channel;
 }
 
+int mk_channel_release(mk_channel *channel)
+{
+    mk_mem_free(channel);
+}
+
 static inline size_t channel_write_in_file(struct mk_channel *channel,
                                            struct mk_stream_input *in)
 {


### PR DESCRIPTION
Added `mk_channel_release` which was missing and is required to prevent a memory leak in fluent-bit.

Signed-off-by: Leonardo Alminana <leonardo@calyptia.com>