### PR TITLE
plugin: auth: Fix building error on auth plugin

### DIFF
--- a/include/monkey/mk_config.h
+++ b/include/monkey/mk_config.h
@@ -194,7 +194,6 @@ struct mk_server
 };
 
 /* Functions */
-struct mk_server_config *mk_config_init();
 void mk_config_start_configure(struct mk_server *server);
 void mk_config_signature(struct mk_server *server);
 void mk_config_add_index(char *indexname);

--- a/include/monkey/mk_plugin.h
+++ b/include/monkey/mk_plugin.h
@@ -104,7 +104,7 @@ struct plugin_api
     /* Async Network */
     struct mk_net_connection *(*net_conn_create) (char *, int);
 
-    struct mk_server_config *config;
+    struct mk_list *hosts;
     struct mk_list *plugins;
 
     /* Error helper */

--- a/mk_server/mk_plugin.c
+++ b/mk_server/mk_plugin.c
@@ -277,7 +277,7 @@ void mk_plugin_api_init(struct mk_server *server)
 #endif
 
     /* Setup and connections list */
-    /* FIXME: api->config = server; */
+    api->hosts = &server->hosts;
 
     /* API plugins funcions */
 

--- a/plugins/auth/conf.c
+++ b/plugins/auth/conf.c
@@ -146,7 +146,7 @@ int mk_auth_conf_init_users_list()
 
     /* vhost configuration */
     struct mk_list *head_hosts;
-    struct mk_list *hosts = &mk_api->config->hosts;
+    struct mk_list *hosts = mk_api->hosts;
     struct mk_list *head_sections;
     struct mk_vhost *entry_host;
     struct mk_rconf_section *section;


### PR DESCRIPTION
This error might be introduced in:
c1c0445f6214fd6cc74ec6a530585f9130bc65c2

This is a possible fix for https://github.com/monkey/monkey/issues/364.

Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>