### PR TITLE
list: add mk_list_add_before

### DIFF
--- a/include/monkey/mk_core/mk_list.h
+++ b/include/monkey/mk_core/mk_list.h
@@ -82,6 +82,29 @@ static inline void mk_list_add_after(struct mk_list *_new,
     next->prev = _new;
 }
 
+static inline void mk_list_add_before(struct mk_list *_new,
+                                      struct mk_list *next,
+                                      struct mk_list *head)
+{
+    struct mk_list *prev;
+
+    if (_new == NULL || next == NULL || head == NULL) {
+        return;
+    }
+
+    if ((head->prev == head && head->next == head) /*empty*/||
+        next == head) {
+        mk_list_add(_new, head);
+        return;
+    }
+
+    prev = next->prev;
+    _new->next = next;
+    _new->prev = prev;
+    prev->next = _new;
+    next->prev = _new;
+}
+
 static inline void __mk_list_del(struct mk_list *prev, struct mk_list *next)
 {
     prev->next = next;

--- a/include/monkey/mk_core/mk_list.h
+++ b/include/monkey/mk_core/mk_list.h
@@ -111,6 +111,30 @@ static inline void mk_list_add_before(struct mk_list *_new,
     next->prev = _new;
 }
 
+static inline void mk_list_append(struct mk_list *_new, struct mk_list *head)
+{
+    if (mk_list_is_empty(head) == 0) {
+        __mk_list_add(_new, head->prev, head);
+    }
+    else {
+        mk_list_add_after(_new,
+                          head->prev,
+                          head);
+    }
+}
+
+static inline void mk_list_prepend(struct mk_list *_new, struct mk_list *head)
+{
+    if (mk_list_is_empty(head) == 0) {
+        __mk_list_add(_new, head->prev, head);
+    }
+    else {
+        mk_list_add_before(_new,
+                           head->next,
+                           head);
+    }
+}
+
 static inline void __mk_list_del(struct mk_list *prev, struct mk_list *next)
 {
     prev->next = next;

--- a/include/monkey/mk_core/mk_list.h
+++ b/include/monkey/mk_core/mk_list.h
@@ -82,6 +82,12 @@ static inline void mk_list_add_after(struct mk_list *_new,
     next->prev = _new;
 }
 
+static inline int mk_list_is_empty(struct mk_list *head)
+{
+    if (head->next == head) return 0;
+    else return -1;
+}
+
 static inline void mk_list_add_before(struct mk_list *_new,
                                       struct mk_list *next,
                                       struct mk_list *head)
@@ -92,7 +98,7 @@ static inline void mk_list_add_before(struct mk_list *_new,
         return;
     }
 
-    if ((head->prev == head && head->next == head) /*empty*/||
+    if (mk_list_is_empty(head) == 0 /*empty*/||
         next == head) {
         mk_list_add(_new, head);
         return;
@@ -116,12 +122,6 @@ static inline void mk_list_del(struct mk_list *entry)
     __mk_list_del(entry->prev, entry->next);
     entry->prev = NULL;
     entry->next = NULL;
-}
-
-static inline int mk_list_is_empty(struct mk_list *head)
-{
-    if (head->next == head) return 0;
-    else return -1;
 }
 
 static inline int mk_list_is_set(struct mk_list *head)


### PR DESCRIPTION
Fluent-bit project uses monkey as a library.
This patch is to add `mk_list_add_before` to fix a bug of fluent-bit.
https://github.com/fluent/fluent-bit/pull/5590

I found that there is no way to add entry like below case.

1. head
2. head -> val1
3. head -> val2 -> val1

A point is 3, there is no API.

1. mk_list_init(&head)
2. mk_list_add(&val, &head)
3.  ??? 

We can't use `mk_list_add_after(&val2, &head, &head)` since `head->next` and `head->prev` is same value `val1`.
Then it calls `mk_list_add` the list will be `head->val1->val2`
https://github.com/monkey/monkey/blob/992749ec1e8e2bc5b8cbcf1cf4fde67d297354cc/include/monkey/mk_core/mk_list.h#L73