### PR TITLE
core: event: kqueue: Don't use NOTE_SECONDS on macOS

### DIFF
--- a/mk_core/mk_event_kqueue.c
+++ b/mk_core/mk_event_kqueue.c
@@ -201,12 +201,14 @@ static inline int _mk_event_timeout_create(struct mk_event_ctx *ctx,
     event->_priority_head.next = NULL;
     event->_priority_head.prev = NULL;
 
-#ifdef NOTE_SECONDS
+#if defined(NOTE_SECONDS) && !defined(__APPLE__)
     /* FreeBSD or LINUX_KQUEUE defined */
     /* TODO : high resolution interval support. */
     EV_SET(&ke, fd, EVFILT_TIMER, EV_ADD, NOTE_SECONDS, sec, event);
 #else
     /* Other BSD have no NOTE_SECONDS & specify milliseconds */
+    /* Also, on macOS, NOTE_SECONDS has severe side effect that cause
+     * performance degradation. */
     EV_SET(&ke, fd, EVFILT_TIMER, EV_ADD, 0, (sec * 1000) + (nsec / 1000000) , event);
 #endif
     ret = kevent(ctx->kfd, &ke, 1, NULL, 0, NULL);


### PR DESCRIPTION
When using NOTE_SECONDS side of EV_SET routine on macOS,
we got a severe performance degradation on threaded input plugin
environment.
Instead, we shouldn't use NOTE_SECONDS event filtering flag and
specify as milliseconds on macOS.

Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>