### PR TITLE
core: event: add mk_event_channel_destroy function for mk_event_chanel_create.

### DIFF
--- a/include/monkey/mk_core/mk_event.h
+++ b/include/monkey/mk_core/mk_event.h
@@ -142,6 +142,8 @@ int mk_event_timeout_disable(struct mk_event_loop *loop, void *data);
 int mk_event_timeout_destroy(struct mk_event_loop *loop, void *data);
 int mk_event_channel_create(struct mk_event_loop *loop,
                             int *r_fd, int *w_fd, void *data);
+int mk_event_channel_destroy(struct mk_event_loop *loop,
+                             int r_fd, int w_fd, void *data);
 int mk_event_wait(struct mk_event_loop *loop);
 int mk_event_wait_2(struct mk_event_loop *loop, int timeout);
 int mk_event_translate(struct mk_event_loop *loop);

--- a/mk_core/mk_event.c
+++ b/mk_core/mk_event.c
@@ -176,6 +176,18 @@ int mk_event_channel_create(struct mk_event_loop *loop,
     return _mk_event_channel_create(ctx, r_fd, w_fd, data);
 }
 
+/* Destroy channel created to distribute signals */
+int mk_event_channel_destroy(struct mk_event_loop *loop,
+                            int r_fd, int w_fd,
+                            void *data)
+{
+    struct mk_event_ctx *ctx;
+
+    mk_bug(!data);
+    ctx = loop->data;
+    return _mk_event_channel_destroy(ctx, r_fd, w_fd, data);
+}
+
 /* Poll events */
 int mk_event_wait(struct mk_event_loop *loop)
 {

--- a/mk_core/mk_event_epoll.c
+++ b/mk_core/mk_event_epoll.c
@@ -368,6 +368,29 @@ static inline int _mk_event_channel_create(struct mk_event_ctx *ctx,
     return 0;
 }
 
+static inline int _mk_event_channel_destroy(struct mk_event_ctx *ctx,
+                                            int r_fd, int w_fd, void *data)
+{
+    struct mk_event *event;
+    int ret;
+
+
+    event = (struct mk_event *)data;
+    if (event->fd != r_fd) {
+        return -1;
+    }
+
+    ret = _mk_event_del(ctx, event);
+    if (ret != 0) {
+        return ret;
+    }
+
+    close(r_fd);
+    close(w_fd);
+
+    return 0;
+}
+
 static inline int _mk_event_inject(struct mk_event_loop *loop,
                                    struct mk_event *event,
                                    int mask,

--- a/mk_core/mk_event_kqueue.c
+++ b/mk_core/mk_event_kqueue.c
@@ -285,6 +285,29 @@ static inline int _mk_event_channel_create(struct mk_event_ctx *ctx,
     return 0;
 }
 
+static inline int _mk_event_channel_destroy(struct mk_event_ctx *ctx,
+                                            int r_fd, int w_fd, void *data)
+{
+    struct mk_event *event;
+    int ret;
+
+
+    event = (struct mk_event *)data;
+    if (event->fd != r_fd) {
+        return -1;
+    }
+
+    ret = _mk_event_del(ctx, event);
+    if (ret != 0) {
+        return ret;
+    }
+
+    close(r_fd);
+    close(w_fd);
+
+    return 0;
+}
+
 static inline int _mk_event_inject(struct mk_event_loop *loop,
                                    struct mk_event *event,
                                    int mask,

--- a/mk_core/mk_event_libevent.c
+++ b/mk_core/mk_event_libevent.c
@@ -355,6 +355,29 @@ static inline int _mk_event_channel_create(struct mk_event_ctx *ctx,
     return 0;
 }
 
+static inline int _mk_event_channel_destroy(struct mk_event_ctx *ctx,
+                                            int r_fd, int w_fd, void *data)
+{
+    struct mk_event *event;
+    int ret;
+
+
+    event = (struct mk_event *)data;
+    if (event->fd != r_fd) {
+        return -1;
+    }
+
+    ret = _mk_event_del(ctx, event);
+    if (ret != 0) {
+        return ret;
+    }
+
+    evutil_closesocket(r_fd);
+    evutil_closesocket(w_fd);
+
+    return 0;
+}
+
 static inline int _mk_event_inject(struct mk_event_loop *loop,
                                    struct mk_event *event,
                                    int mask,

--- a/mk_core/mk_event_select.c
+++ b/mk_core/mk_event_select.c
@@ -320,6 +320,29 @@ static inline int _mk_event_channel_create(struct mk_event_ctx *ctx,
     return 0;
 }
 
+static inline int _mk_event_channel_destroy(struct mk_event_ctx *ctx,
+                                            int r_fd, int w_fd, void *data)
+{
+    struct mk_event *event;
+    int ret;
+
+
+    event = (struct mk_event *)data;
+    if (event->fd != r_fd) {
+        return -1;
+    }
+
+    ret = _mk_event_del(ctx, event);
+    if (ret != 0) {
+        return ret;
+    }
+
+    close(r_fd);
+    close(w_fd);
+
+    return 0;
+}
+
 static inline int _mk_event_inject(struct mk_event_loop *loop,
                                    struct mk_event *event,
                                    int mask,


### PR DESCRIPTION
Add a new function mk_event_channel_destroy which destroys channels created by mk_event_channel_create as well as closing the file descriptors it opened.