### PR TITLE
Improve toolchain support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,6 +178,8 @@ endif()
 # Use old Pthread TLS
 if(NOT MK_PTHREAD_TLS)
   check_c_source_compiles("
+     #include <sys/types.h>
+     extern void *__tls_get_addr(size_t *v);
      __thread int a;
      int main() {
          __tls_get_addr(0);

--- a/mk_core/CMakeLists.txt
+++ b/mk_core/CMakeLists.txt
@@ -61,6 +61,7 @@ set(src "${src}"
   )
 
 check_c_source_compiles("
+  #define _GNU_SOURCE
   #include <string.h>
   int main() {
      char  haystack[] = \"1234\";


### PR DESCRIPTION
Minor changes that improve compatibility with other toolchains than GCC and glibc. This is useful for embedded environments. Patches originating in [meta-openembedded](https://git.openembedded.org/meta-openembedded/commit/?id=0f8dced8c7b76a41af211d57add34f5284e9733e).