### PR TITLE
fastcgi: Use value instead of address of sin6_port

### DIFF
--- a/plugins/fastcgi/fcgi_handler.c
+++ b/plugins/fastcgi/fcgi_handler.c
@@ -247,7 +247,7 @@ static inline int fcgi_add_param_net(struct fcgi_handler *handler)
             struct sockaddr_in *s4 = (struct sockaddr_in *)&addr4;
             memset(&addr4, 0, sizeof(addr4));
             addr4.sin_family = AF_INET;
-            addr4.sin_port = &s->sin6_port;
+            addr4.sin_port = s->sin6_port;
             memcpy(&addr4.sin_addr.s_addr,
                    s->sin6_addr.s6_addr + 12,
                    sizeof(addr4.sin_addr.s_addr));


### PR DESCRIPTION
This seems to be wrongly assigned where ipv4 sin_port is
equated to address of sin6_port and not value of sin6_port

Signed-off-by: Khem Raj <raj.khem@gmail.com>