### PR TITLE
core and build fixes

### DIFF
--- a/.github/workflows/build-pr.yaml
+++ b/.github/workflows/build-pr.yaml
@@ -20,9 +20,10 @@ jobs:
       - uses: actions/checkout@v2
       - name: Build on ${{ matrix.os }} with vs-2019
         run: |
-          cmake -DMK_DEBUG=On -DMK_WITHOUT_BIN=On -DMK_WITHOUT_CONF=On -DMK_LIB_ONLY=On
-          cd "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\"
-          .\MSBuild.exe $Env:GITHUB_WORKSPACE\monkey.sln /p:Configuration=Release
+          mkdir build
+          cd build
+          cmake -DMK_DEBUG=On -DMK_WITHOUT_BIN=On -DMK_WITHOUT_CONF=On -DMK_LIB_ONLY=On ..\
+          cmake --build . --config Release
 
   build-unix:
     name: Build sources on amd64 for ${{ matrix.os }} - ${{ matrix.compiler }}
@@ -42,8 +43,10 @@ jobs:
       - uses: actions/checkout@v2
       - name: Build on ${{ matrix.os }} with ${{ matrix.compiler }}
         run: |
+          mkdir build
+          cd build
           echo "CC = $CC, CXX = $CXX"
-          cmake -DMK_DEBUG=On -DMK_WITHOUT_BIN=On -DMK_WITHOUT_CONF=On -DMK_LIB_ONLY=On
-          make
+          cmake -DMK_DEBUG=On -DMK_WITHOUT_BIN=On -DMK_WITHOUT_CONF=On -DMK_LIB_ONLY=On ..\
+          cmake --build .
         env:
           CC: ${{ matrix.compiler }}

--- a/.github/workflows/build-pr.yaml
+++ b/.github/workflows/build-pr.yaml
@@ -46,7 +46,7 @@ jobs:
           mkdir build
           cd build
           echo "CC = $CC, CXX = $CXX"
-          cmake -DMK_DEBUG=On -DMK_WITHOUT_BIN=On -DMK_WITHOUT_CONF=On -DMK_LIB_ONLY=On ..\
+          cmake -DMK_DEBUG=On -DMK_WITHOUT_BIN=On -DMK_WITHOUT_CONF=On -DMK_LIB_ONLY=On ../
           cmake --build .
         env:
           CC: ${{ matrix.compiler }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -275,6 +275,8 @@ include_directories(deps/flb_libco)
 include_directories(deps/regex)
 include_directories(include)
 include_directories(include/monkey/)
+include_directories(${CMAKE_CURRENT_BINARY_DIR}/include/)
+include_directories(${CMAKE_CURRENT_BINARY_DIR}/include/monkey/)
 
 if (CMAKE_SYSTEM_NAME MATCHES "Windows")
   include_directories(mk_core/deps/libevent/include)

--- a/include/monkey/mk_core.h
+++ b/include/monkey/mk_core.h
@@ -30,7 +30,7 @@ extern "C" {
 
 #include <sys/types.h>
 
-#include "mk_core/mk_core_info.h"
+#include <mk_core/mk_core_info.h>
 #include "mk_core/mk_pthread.h"
 #include "mk_core/mk_iov.h"
 #include "mk_core/mk_uio.h"

--- a/include/monkey/mk_core/mk_dirent.h
+++ b/include/monkey/mk_core/mk_dirent.h
@@ -20,7 +20,7 @@
 #ifndef MK_DIRENT_H
 #define MK_DIRENT_H
 
-#include "mk_core_info.h"
+#include <mk_core/mk_core_info.h>
 
 #ifdef _WIN32
 #include "external/dirent.h"

--- a/include/monkey/mk_core/mk_getopt.h
+++ b/include/monkey/mk_core/mk_getopt.h
@@ -20,7 +20,7 @@
 #ifndef MK_GETOPT_H
 #define MK_GETOPT_H
 
-#include "mk_core_info.h"
+#include <mk_core/mk_core_info.h>
 
 #ifdef __GNUC__      /* Heaven */
 #include <getopt.h>

--- a/include/monkey/mk_core/mk_pipe.h
+++ b/include/monkey/mk_core/mk_pipe.h
@@ -20,7 +20,7 @@
 #ifndef MK_PIPE_H
 #define MK_PIPE_H
 
-#include "mk_core_info.h"
+#include <mk_core/mk_core_info.h>
 
 /* For Windows we need a workaround to play with pipe(2) */
 #ifdef _WIN32

--- a/include/monkey/mk_core/mk_pthread.h
+++ b/include/monkey/mk_core/mk_pthread.h
@@ -20,7 +20,7 @@
 #ifndef MK_PTHREAD_H
 #define MK_PTHREAD_H
 
-#include "mk_core_info.h"
+#include <mk_core/mk_core_info.h>
 
 #if defined (MK_THREADS_POSIX)    /* Heaven */
 #include <pthread.h>

--- a/include/monkey/mk_core/mk_sleep.h
+++ b/include/monkey/mk_core/mk_sleep.h
@@ -20,7 +20,7 @@
 #ifndef MK_SLEEP_H
 #define MK_SLEEP_H
 
-#include "mk_core_info.h"
+#include <mk_core/mk_core_info.h>
 
 #ifdef __GNUC__      /* Heaven */
 #include <time.h>

--- a/include/monkey/mk_core/mk_string.h
+++ b/include/monkey/mk_core/mk_string.h
@@ -21,7 +21,7 @@
 #define MK_STR_H
 
 #include <stdint.h>
-#include "mk_core_info.h"
+#include <mk_core/mk_core_info.h>
 #include "mk_memory.h"
 #include "mk_list.h"
 #include "mk_macros.h"

--- a/include/monkey/mk_core/mk_uio.h
+++ b/include/monkey/mk_core/mk_uio.h
@@ -1,7 +1,7 @@
 #ifndef MK_UIO_H
 #define MK_UIO_H
 
-#include "mk_core_info.h"
+#include <mk_core/mk_core_info.h>
 
 #ifdef MK_HAVE_SYS_UIO_H
 #include <sys/uio.h>

--- a/include/monkey/mk_core/mk_unistd.h
+++ b/include/monkey/mk_core/mk_unistd.h
@@ -20,7 +20,7 @@
 #ifndef MK_UNISTD_H
 #define MK_UNISTD_H
 
-#include "mk_core_info.h"
+#include <mk_core/mk_core_info.h>
 
 #ifdef MK_HAVE_UNISTD_H
 #include <unistd.h>

--- a/include/monkey/mk_core/mk_utils.h
+++ b/include/monkey/mk_core/mk_utils.h
@@ -79,17 +79,14 @@ extern pthread_key_t mk_utils_error_key;
 #endif
 
 /*
- * Helpers to format and print out common errno errors, we use thread
- * keys to hold a buffer per thread so strerror_r(2) can be used without
- * a memory allocation.
+ * Helpers to format and print out common errno errors.
  */
-#define MK_UTILS_LIBC_ERRNO_BUFFER()                                    \
-    int _err  = errno;                                                  \
-    char bufs[256];                                                     \
-    char *buf = (char *) pthread_getspecific(mk_utils_error_key);       \
-    if (!buf) buf = bufs;                                               \
-    if (strerror_r(_err, buf, MK_UTILS_ERROR_SIZE) != 0) {              \
-        mk_err("strerror_r() failed");                                  \
+#define MK_UTILS_LIBC_ERRNO_BUFFER()                       \
+    char buf[MK_UTILS_ERROR_SIZE];                         \
+    int  _err;                                             \
+    _err = errno;                                          \
+    if (strerror_r(_err, buf, MK_UTILS_ERROR_SIZE) != 0) { \
+        mk_err("strerror_r() failed");                     \
     }
 
 static inline void mk_utils_libc_error(char *caller, char *file, int line)

--- a/mk_core/CMakeLists.txt
+++ b/mk_core/CMakeLists.txt
@@ -145,7 +145,7 @@ endif()
 
 configure_file(
   "${CMAKE_CURRENT_SOURCE_DIR}/../include/monkey/mk_core/mk_core_info.h.in"
-  "${PROJECT_BINARY_DIR}/../include/monkey/mk_core/mk_core_info.h"
+  "${PROJECT_BINARY_DIR}/include/monkey/mk_core/mk_core_info.h" 
   )
 
 add_library(mk_core STATIC ${src})

--- a/mk_core/mk_event_libevent.c
+++ b/mk_core/mk_event_libevent.c
@@ -317,10 +317,16 @@ static inline int _mk_event_timeout_create(struct mk_event_ctx *ctx,
 
 static inline int _mk_event_timeout_destroy(struct mk_event_ctx *ctx, void *data)
 {
+    int              result;
     struct mk_event *event;
+
     event = (struct mk_event *) data;
+
+    result = _mk_event_del(ctx, data);
+
     evutil_closesocket(event->fd);
-    return _mk_event_del(ctx, data);
+
+    return result;
 }
 
 static inline int _mk_event_channel_create(struct mk_event_ctx *ctx,


### PR DESCRIPTION
core: removed TLS usage from a macro that doesn't need it because it caused a memory corruption in certain cases
where a web server instance was not created (mostly test cases but I think running fluent-bit with http_server disabled could cause the same issue)

core: event: libevent: fixed the timer destruction order so we wouldn't try to remove an already closed socket from the event loop

build: fixed the mk_core_info.h generation and inclusion paths (as well as the directives)

Everything was tested in stand alone mode as well as inside fluent-bit with no changes required for it to build and work in either mode.