### PR TITLE
mk_core: Fix always invaild value on if clause at _mk_event_timeout_destroy

### DIFF
--- a/mk_core/mk_event_kqueue.c
+++ b/mk_core/mk_event_kqueue.c
@@ -241,11 +241,10 @@ static inline int _mk_event_timeout_destroy(struct mk_event_ctx *ctx, void *data
         return 0;
     }
 
+    event = (struct mk_event *) data;
     if (!MK_EVENT_IS_REGISTERED(event)) {
         return 0;
     }
-
-    event = (struct mk_event *) data;
     EV_SET(&ke, event->fd, EVFILT_TIMER, EV_DELETE, 0,0, NULL);
 
     ret = kevent(ctx->kfd, &ke, 1, NULL, 0, NULL);


### PR DESCRIPTION
This is because `struct mk_event *event;` variable is not initialized yet before checking MK_EVENT_IS_REGISTERED macro.
It shouldn't put before `event` variable initalization.

When swap the places of cast from void* and the macro, this issue should be solved.

This issue is only occurred on teardown.

Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>