### PR TITLE
mk_server: introduce start event loop in lib mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ src/include/
 build/
 include/monkey/mk_static_plugins.h
 include/monkey/mk_core/mk_core_info.h
+.vscode

--- a/include/monkey/mk_config.h
+++ b/include/monkey/mk_config.h
@@ -151,10 +151,14 @@ struct mk_server
     int  server_signature_header_len;
 
     /* Library  mode */
-    int lib_mode;                   /* is running in Library mode ? */
-    int lib_ch_manager[2];          /* lib channel manager */
-    struct mk_event_loop *lib_evl;  /* lib event loop */
-    struct mk_event  lib_ch_event;  /* lib channel manager event ? */
+    int lib_mode;                        /* is running in Library mode ? */
+
+    int lib_ch_manager[2];               /* lib channel manager */
+    struct mk_event_loop *lib_evl;       /* lib event loop */
+    struct mk_event  lib_ch_event;       /* lib channel manager event ? */
+    int lib_ch_start[2];                 /* lib start signal channel */
+    struct mk_event_loop *lib_evl_start; /* lib start event loop */
+    struct mk_event lib_ch_start_event;  /* lib start event */
 
     /* Scheduler context (struct mk_sched_ctx) */
     void *sched_ctx;

--- a/mk_server/mk_lib.c
+++ b/mk_server/mk_lib.c
@@ -196,8 +196,8 @@ int mk_start(mk_ctx_t *ctx)
     ctx->worker_tid = tid;
 
     /* Wait for the started signal so we can return to the caller */
-    mk_event_wait(server->lib_evl);
-    mk_event_foreach(event, server->lib_evl) {
+    mk_event_wait(server->lib_evl_start);
+    mk_event_foreach(event, server->lib_evl_start) {
         fd = event->fd;
 
         /* When using libevent _mk_event_channel_create creates a unix socket
@@ -222,6 +222,8 @@ int mk_start(mk_ctx_t *ctx)
             return -1;
         }
     }
+
+    mk_event_loop_destroy(server->lib_evl_start);
 
     return 0;
 }

--- a/mk_server/mk_server.c
+++ b/mk_server/mk_server.c
@@ -634,19 +634,18 @@ static int mk_server_lib_notify_started(struct mk_server *server)
     uint64_t val;
 
     /* Check the channel is valid (enabled by library mode) */
-    if (server->lib_ch_manager[1] <= 0) {
+    if (server->lib_ch_start[1] <= 0) {
         return -1;
     }
 
     val = MK_SERVER_SIGNAL_START;
 
 #ifdef _WIN32
-    return send(server->lib_ch_manager[1], &val, sizeof(uint64_t), 0);
+    return send(server->lib_ch_start[1], &val, sizeof(uint64_t), 0);
 #else
-    return write(server->lib_ch_manager[1], &val, sizeof(uint64_t));
+    return write(server->lib_ch_start[1], &val, sizeof(uint64_t));
 #endif
 }
-
 
 void mk_server_loop(struct mk_server *server)
 {

--- a/mk_server/monkey.c
+++ b/mk_server/monkey.c
@@ -122,6 +122,27 @@ struct mk_server *mk_server_create()
         return NULL;
     }
 
+    /* Library mode: start event loop */
+    server->lib_evl = mk_event_loop_create(1);
+    if (!server->lib_evl) {
+        mk_mem_free(server);
+        return NULL;
+    }
+
+    memset(&server->lib_ch_start_event, 0, sizeof(struct mk_event));
+
+    ret = mk_event_channel_create(server->lib_evl_start,
+                                  &server->lib_ch_start[0],
+                                  &server->lib_ch_start[1],
+                                  &server->lib_ch_start_event);
+
+    if (ret != 0) {
+        mk_event_loop_destroy(server->lib_evl);
+        mk_event_loop_destroy(server->lib_evl_start);
+        mk_mem_free(server);
+        return NULL;
+    }
+
     /* Initialize linked list heads */
     mk_list_init(&server->plugins);
     mk_list_init(&server->sched_worker_callbacks);


### PR DESCRIPTION
Closes #380 

This patch addresses a race condition in `mk_start` under `MK_SCHEDULER_FAIR_BALANCING` mode wherein the worker started by `mk_start` could accidentally receive the `MK_SERVER_SIGNAL_START` it is trying to send to the main thread. This patch introduces `mk_server->lib_evl_start`, which is a small event loop used exclusively by the `mk_start` thread to receive the start signal from the worker. This eliminates the race condition, since the worker and main thread will no longer be racing to receive the `MK_SERVER_SIGNAL_START` signal.

Signed-off-by: braydonk <braydonk@google.com>