### PR TITLE
server: use cross platform socket close

### DIFF
--- a/mk_server/mk_server.c
+++ b/mk_server/mk_server.c
@@ -157,7 +157,7 @@ void mk_server_listen_exit(struct mk_list *list)
 
     mk_list_foreach_safe(head, tmp, list) {
         listen = mk_list_entry(head, struct mk_server_listen, _head);
-        close(listen->server_fd);
+        mk_event_closesocket(listen->server_fd);
         mk_list_del(&listen->_head);
         mk_mem_free(listen);
     }


### PR DESCRIPTION
Closes #382 

`mk_server_listen_exit` previously used `close` to close the server file descriptor. On Windows it needs to be `closesocket`. This PR switches that function to use the cross-platform `mk_event_closesocket`.

Signed-off-by: braydonk <braydonk@google.com>