### PR TITLE
eventloop: zero priority linked list on init

### DIFF
--- a/mk_core/mk_event_epoll.c
+++ b/mk_core/mk_event_epoll.c
@@ -142,7 +142,11 @@ static inline int _mk_event_add(struct mk_event_ctx *ctx, int fd,
 
     event->mask = events;
     event->priority = MK_EVENT_PRIORITY_DEFAULT;
-    mk_list_entry_init(&event->_priority_head);
+
+    /* Remove from priority queue */
+    if (!mk_list_entry_is_orphan(&event->_priority_head)) {
+        mk_list_del(&event->_priority_head);
+    }
 
     return ret;
 }

--- a/mk_core/mk_event_kqueue.c
+++ b/mk_core/mk_event_kqueue.c
@@ -130,7 +130,11 @@ static inline int _mk_event_add(struct mk_event_ctx *ctx, int fd,
 
     event->mask = events;
     event->priority = MK_EVENT_PRIORITY_DEFAULT;
-    mk_list_entry_init(&event->_priority_head);
+
+    /* Remove from priority queue */
+    if (!mk_list_entry_is_orphan(&event->_priority_head)) {
+        mk_list_del(&event->_priority_head);
+    }
 
     return 0;
 }

--- a/mk_core/mk_event_libevent.c
+++ b/mk_core/mk_event_libevent.c
@@ -196,7 +196,11 @@ static inline int _mk_event_add(struct mk_event_ctx *ctx, evutil_socket_t fd,
     event->data   = ev_map;
 
     event->priority = MK_EVENT_PRIORITY_DEFAULT;
-    mk_list_entry_init(&event->_priority_head);
+
+    /* Remove from priority queue */
+    if (!mk_list_entry_is_orphan(&event->_priority_head)) {
+        mk_list_del(&event->_priority_head);
+    }
 
     /* Register into libevent */
     flags |= EV_PERSIST;

--- a/mk_core/mk_event_select.c
+++ b/mk_core/mk_event_select.c
@@ -120,7 +120,11 @@ static inline int _mk_event_add(struct mk_event_ctx *ctx, int fd,
     event->status = MK_EVENT_REGISTERED;
 
     event->priority = MK_EVENT_PRIORITY_DEFAULT;
-    mk_list_entry_init(&event->_priority_head);
+
+    /* Remove from priority queue */
+    if (!mk_list_entry_is_orphan(&event->_priority_head)) {
+        mk_list_del(&event->_priority_head);
+    }
 
     if (type != MK_EVENT_UNMODIFIED) {
         event->type = type;

--- a/mk_server/mk_fifo.c
+++ b/mk_server/mk_fifo.c
@@ -34,7 +34,7 @@ static struct mk_fifo_worker *mk_fifo_worker_create(struct mk_fifo *ctx,
     /* Get an ID */
     id = mk_list_size(&ctx->workers);
 
-    fw = mk_mem_alloc(sizeof(struct mk_fifo_worker));
+    fw = mk_mem_alloc_z(sizeof(struct mk_fifo_worker));
     if (!fw) {
         perror("malloc");
         return NULL;

--- a/mk_server/mk_net.c
+++ b/mk_server/mk_net.c
@@ -97,7 +97,7 @@ struct mk_net_connection *mk_net_conn_create(char *addr, int port)
     struct mk_net_connection *conn;
 
     /* Allocate connection context */
-    conn = mk_mem_alloc(sizeof(struct mk_net_connection));
+    conn = mk_mem_alloc_z(sizeof(struct mk_net_connection));
     if (!conn) {
         return NULL;
     }


### PR DESCRIPTION
> Note to the reviewer: This change requires from now on that when creating an event in memory, `MK_EVENT_ZERO()` is called or else a segfault on `mk_event_add()` will occur.

## Problem
Currently if an event is added to the event loop twice, an error can occur where the ready list (priority list) is corrupted, as the link list in the event is zeroed.

## Solution Difficulties
Since mk_event may be uninitialized memory, we have no way of tracking whether the event has been added to the loop before

~~## Solution
Require that MK_EVENT_ZERO is always called before the mk_event_add() function is called. Then we know if we should remove records of the event from the loop before adding again.~~

~~## Honest Comments~~
~~Honestly, I'm not a huge fan of this solution, as it means that if we forget to zero an mk_event after creating it, the introduced code in `mk_event_add` will segfault, since it expects that the linked list is either 0 or valid, and will try to remove the event if non zero. ~~

~~However it was the most reasonable option we could think of. And we thought it would make sense to require some sort of initialization function for the mk_list's memory~~

~~## Other Options to Consider~~
~~1. Require that the same events are not added multiple times without being first deleted.
2. Add memory to the event loop context to track what events have been added. That way additional adds won't corrupt the event loop.
3. Introduce a new function to Fluent Bit called `mk_event_add_safe()` that checks the event loop's internal priority loops for references to the event and removes it before calling the normal mk_add. (this requires enumerating the list for each add)~~

## New Minimal Solution
In order to reduce the potential for this change to break things, and following suggestions of Leonardo, we are changing all event memory initialization to calloc (mk_mem_alloc_z). We will assume that on creation, the linked list _priority_head in the event will be set to 0. This will be maintained by mk_event_add and mk_event_del. MK_EVENT_ZERO, MK_EVENT_NEW, MK_EVENT_INIT are not changed.

## To Keep in Mind
From now on, wherever memory for an event is allocated, that event's memory should be zero.
This [Fluent Bit PR](https://github.com/fluent/fluent-bit/pull/7088) ensures that on memory allocation, event memory is initialized to zero.

## MK Event Proper Event Initialization Notes
Allocation of events before MK_EVENT_INIT, MK_EVENT_ZERO, MK_EVENT_NEW (ie, outside of mk_core/)

MK_EVENT_INIT - None
MK_EVENT_ZERO - None
MK_EVENT_NEW

    mk_fifo.c - fw->event
        changed fw to be allocated with zero
    mk_http_thread.c - channel->event (event is a pointer)
        Finding where this event is allocated is tricky. The event pointer is set in mk_sched_add_connection from conn which is allocated with mk_mem_alloc_z on line 200 of mk_scheduler.c, see: https://github.com/fala-aws/monkey/blob/67d9fd61e1ff294f5c08f69444d0861639ea4286/mk_server/mk_scheduler.c#L200
    mk_net.c
        The first 2 instances are from conn which is an mk_net_connection holding an event
            change conn to be allocated with mk_mem_alloc_z
        The second 2 instances are from channel->event which is a pointer. This is same as mk_http_thread. The event is initialized via mk_mem_alloc_z()

Summary of changes:

    mk_mem_alloc -> mk_mem_alloc_z for fw, containing an event
    mk_mem_alloc -> mk_mem_alloc_z for mk_net_connection, containing an event
