### PR TITLE
core: removed alloca calls from the memmem replacement function

### DIFF
--- a/mk_core/mk_string.c
+++ b/mk_core/mk_string.c
@@ -53,56 +53,37 @@ void *memrchr(const void *s, int c, size_t n)
 void *memmem(const void *haystack, size_t haystacklen,
              const void *needle, size_t needlelen)
 {
-    uint8_t *null_terminated_haystack_buffer;
-    uint8_t *null_terminated_needle_buffer;
-    uint8_t  free_haystack_buffer;
-    uint8_t  free_needle_buffer;
-    void    *result;
+    char *null_terminated_haystack_buffer;
+    char *null_terminated_needle_buffer;
+    void *result;
 
     result = NULL;
 
-    free_haystack_buffer = 0;
-    free_needle_buffer = 0;
-
-    if(1024 > haystacklen){
-        null_terminated_haystack_buffer = (uint8_t *)_alloca(haystacklen + 1);
-    }
-    else
-    {
-        null_terminated_haystack_buffer = (uint8_t*)malloc(haystacklen + 1);
-        free_haystack_buffer = 1;
-    }
+    null_terminated_haystack_buffer = (char *) calloc(haystacklen + 1,
+                                                      sizeof(char));
 
     if(NULL != null_terminated_haystack_buffer){
-        if(1024 > needlelen){
-            null_terminated_needle_buffer = (uint8_t*)_alloca(needlelen + 1);
-        }
-        else
-        {
-            null_terminated_needle_buffer = (uint8_t*)malloc(needlelen + 1);
-            free_needle_buffer = 1;
-        }
+        null_terminated_needle_buffer = (char *) calloc(needlelen + 1,
+                                                        sizeof(char));
 
         if(NULL != null_terminated_needle_buffer){
-            memset(null_terminated_haystack_buffer, 0, haystacklen + 1);
-
-            memcpy(null_terminated_haystack_buffer, haystack, haystacklen);
-
-            memset(null_terminated_needle_buffer, 0, needlelen + 1);
-
-            memcpy(null_terminated_needle_buffer, needle, needlelen);
+            strncpy(null_terminated_haystack_buffer, haystack, haystacklen);
+            strncpy(null_terminated_needle_buffer, needle, needlelen);
 
             result = strstr(null_terminated_haystack_buffer, 
                             null_terminated_needle_buffer);
 
-            if(free_needle_buffer){
-                free(null_terminated_needle_buffer);
+            if (result != NULL) {
+                result = (void *)
+                    ((((uintptr_t) null_terminated_haystack_buffer) - \
+                      ((uintptr_t) result)) +
+                     ((uintptr_t) haystack));
             }
+
+            free(null_terminated_needle_buffer);
         }
 
-        if(free_haystack_buffer){
-            free(null_terminated_haystack_buffer);
-        }
+        free(null_terminated_haystack_buffer);
     }
 
     return result;


### PR DESCRIPTION
Note: this function returned an invalid pointer to released memory