### PR TITLE
mk_event_epoll: fix uninitialised value

### DIFF
--- a/mk_core/mk_event_epoll.c
+++ b/mk_core/mk_event_epoll.c
@@ -105,6 +105,7 @@ static inline int _mk_event_add(struct mk_event_ctx *ctx, int fd,
     int ret;
     struct mk_event *event;
     struct epoll_event ep_event;
+    memset(&ep_event, 0, sizeof(ep_event));
 
     mk_bug(ctx == NULL);
     mk_bug(data == NULL);


### PR DESCRIPTION
Fix error:

"Uninitialised value was created by a stack allocation" at `_mk_event_add`

Addresses: #399 