### PR TITLE
core: utils: fix off-by-one error when defining length of pidstr

### DIFF
--- a/mk_core/mk_utils.c
+++ b/mk_core/mk_utils.c
@@ -329,7 +329,7 @@ int mk_utils_register_pid(char *path)
 {
     int fd;
     int ret;
-    char pidstr[MK_MAX_PID_LEN];
+    char pidstr[MK_MAX_PID_LEN + 1];
     struct flock lock;
     struct stat sb;
 


### PR DESCRIPTION
MK_MAX_PID_LEN is max amount of pid digits, not including the null terminator.