### PR TITLE
winpthreads: fix off by one bug in pthread_setspecific which impedes setting values

### DIFF
--- a/mk_core/external/winpthreads.c
+++ b/mk_core/external/winpthreads.c
@@ -1098,7 +1098,7 @@ int pthread_setspecific(pthread_key_t key, const void *value)
 {
   pthread_t t = pthread_self();
 
-  if (key > t->keymax)
+  if (key >= t->keymax)
   {
     int keymax = (key + 1) * 2;
     void **kv = (void**)realloc(t->keyval, keymax * sizeof(void *));


### PR DESCRIPTION
# Summary

Without this patch values with a key equal to the maximum will not be set and will return NULL when calling `pthread_getspecific`.
