### PR TITLE
core: event: Fix typo in mk_event_select.c.

### DIFF
--- a/mk_core/mk_event_select.c
+++ b/mk_core/mk_event_select.c
@@ -367,7 +367,7 @@ static inline int _mk_event_inject(struct mk_event_loop *loop,
 
     if (prevent_duplication) {
         for (index = 0 ; index < loop->n_events ; index++) {
-            if (ctx->fired[index]->fd == event->fd) {
+            if (ctx->fired[index].data == event) {
                 return 0;
             }
         }
@@ -375,7 +375,7 @@ static inline int _mk_event_inject(struct mk_event_loop *loop,
 
     event->mask = mask;
 
-    ctx->fired[loop->n_events] = event;
+    ctx->fired[loop->n_events].data = event;
 
     loop->n_events++;
 


### PR DESCRIPTION
Fixes a type error introduced in #359:
```
…/mk_core/mk_event_select.c:370:34: error: invalid type argument of '->' (have 'struct mk_event')
  370 |             if (ctx->fired[index]->fd == event->fd) {
      |                                  ^~
…/mk_core/mk_event_select.c:378:34: error: incompatible types when assigning to type 'struct mk_event' from type 'struct mk_event *'
  378 |     ctx->fired[loop->n_events] = event;
      |                                  ^~~~~
```