### PR TITLE
fix: set log file permissions to 0600, closes CVE-2013-1771

### DIFF
--- a/plugins/logger/logger.c
+++ b/plugins/logger/logger.c
@@ -197,7 +197,7 @@ static void mk_logger_start_worker(void *args)
 
             timeout = clk + mk_logger_timeout;
 
-            flog = open(target, O_WRONLY | O_CREAT | O_CLOEXEC, 0644);
+            flog = open(target, O_WRONLY | O_CREAT | O_CLOEXEC, 0600);
             if (mk_unlikely(flog == -1)) {
                 mk_warn("Could not open logfile '%s' (%s)", target, strerror(errno));
 
@@ -327,7 +327,7 @@ int mk_logger_plugin_init(struct plugin_api **api, char *confdir)
 
     /* Check masterlog */
     if (mk_logger_master_path) {
-        fd = open(mk_logger_master_path, O_WRONLY | O_CREAT | O_CLOEXEC, 0644);
+        fd = open(mk_logger_master_path, O_WRONLY | O_CREAT | O_CLOEXEC, 0600);
         if (fd == -1) {
             mk_err("Could not open/create master logfile %s", mk_logger_master_path);
             exit(EXIT_FAILURE);


### PR DESCRIPTION
Apologies for opening an issue on a very old CVE, do feel free to close as unwanted.

We are currently doing a CVE triage for Yocto and found that CVE-2013-1771 still applies to the current version.

I couldn’t find a trace that this CVE report ever made it to this project, and I thought while I’m in here, I’ll offer a fix, if it is wanted.

The original description can be found here: https://www.openwall.com/lists/oss-security/2013/02/26/10

If this gets merged, I’m also happy to notify NIST to update https://nvd.nist.gov/vuln/detail/CVE-2013-1771 with the future fix version.

Again, if this is not desired, do feel free to close with or without comment, no hard feelings :)