### PR TITLE
CMakelists.txt: Stop using Make automatic variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,10 +15,8 @@ include(GNUInstallDirs)
 # Set default compiler options
 if (NOT CMAKE_SYSTEM_NAME MATCHES "Windows")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99 -Wall -Wextra")
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D__FILENAME__='\"$$(subst ${CMAKE_SOURCE_DIR}/,,$$(abspath \$$<))\"'")
-else()
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D__FILENAME__=__FILE__")
 endif()
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D__FILENAME__=__FILE__")
 
 # Monkey Version
 set(MK_VERSION_MAJOR  1)


### PR DESCRIPTION
CMake Makefile layout generation has changed since version 3.20, ref: https://discourse.cmake.org/t/base-filename-gets-set-to-compiler-depend-ts-after-update-to-cmake-3-20/3075/4

For instance with Yocto framework this approach can lead to QA issue stemming from build host path ending up in generated binary like

>  ERROR: fluentbit-3.1.9-r0 do_package_qa: QA Issue: File /usr/bin/fluent-bit in package fluentbit contains reference to TMPDIR [buildpaths]
>  ERROR: fluentbit-3.1.9-r0 do_package_qa: Fatal QA errors were found, failing task.

stemming from
```sh
  $ strings packages-split/fluentbit/usr/bin/fluent-bit
  ...
  $(subst /yocto/upstream/build/tmp/work/cortexa57-poky-linux/fluentbit/3.1.9/git/,,$(abspath $<))
  ...
  ```

--

On related note, I was inspired to open this pull request by feedback from Fluent Bit project maintainer in https://github.com/fluent/fluent-bit/pull/9450#issuecomment-2385353687