### PR TITLE
core: winuio: Fix send function arguments type glitch and include stdint.h if available on MSVC

### DIFF
--- a/include/monkey/mk_core/external/winuio.h
+++ b/include/monkey/mk_core/external/winuio.h
@@ -36,7 +36,7 @@ static inline ssize_t writev(int fildes, const struct mk_iovec *iov, int iovcnt)
     for (i = 0; i < iovcnt; i++) {
         int len;
 
-        len = send((SOCKET)fildes, iov[i].iov_base, (int)iov[i].iov_len, 0);
+        len = send((SOCKET)fildes, (char *)iov[i].iov_base, (int)iov[i].iov_len, 0);
         if (len == SOCKET_ERROR) {
                 uint32_t err = GetLastError();
             // errno = win_to_posix_error(err);

--- a/include/monkey/mk_core/mk_dep_unistd.h
+++ b/include/monkey/mk_core/mk_dep_unistd.h
@@ -44,6 +44,9 @@
 #define STDOUT_FILENO 1
 #define STDERR_FILENO 2
 /* should be in some equivalent to <sys/types.h> */
+#if _MSC_VER >= 1600   /* MSVC 2010 or higher */
+#include <stdint.h>
+#else
 typedef __int8            int8_t;
 typedef __int16           int16_t;
 typedef __int32           int32_t;
@@ -52,5 +55,6 @@ typedef unsigned __int8   uint8_t;
 typedef unsigned __int16  uint16_t;
 typedef unsigned __int32  uint32_t;
 typedef unsigned __int64  uint64_t;
+#endif
 
 #endif /* unistd.h  */


### PR DESCRIPTION
During debugging on weird compilation failures, I found two issues for potential compilation errors on MSVC.
Currently, it was concealed implicitly but once we'll include flb_mem.h in another place from the ordinary ones, the following errors are generated:

```
flb_simdutf_connector.cpp
D:\a\fluent-bit\fluent-bit\lib\monkey\include\monkey\mk_core\external/winuio.h(39): error C2664: 'int send(SOCKET,const char *,int,int)': cannot convert argument 2 from 'void *const ' to 'const char *'
D:\a\fluent-bit\fluent-bit\lib\monkey\include\monkey\mk_core\external/winuio.h(39): note: Conversion from 'void*' to pointer to non-'void' requires an explicit cast
C:\Program Files (x86)\Windows Kits\10\\include\10.0.26100.0\\um\winsock2.h(2085): note: see declaration of 'send'
D:\a\fluent-bit\fluent-bit\lib\monkey\include\monkey\mk_core\external/winuio.h(39): note: while trying to match the argument list '(SOCKET, void *const , int, int)'
D:\a\fluent-bit\fluent-bit\lib\monkey\include\monkey\mk_core/mk_iov.h(115): warning C4805: '==': unsafe mix of type 'int' and type 'bool' in operation
D:\a\fluent-bit\fluent-bit\lib\monkey\include\monkey\mk_core\mk_dep_unistd.h(47): error C2371: 'int8_t': redefinition; different basic types
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.43.34808\include\stdint.h(18): note: see declaration of 'int8_t'
NMAKE : fatal error U1077: '"C:\Program Files\CMake\bin\cmake.exe" -E cmake_cl_compile_depends --dep-file=CMakeFiles\flb-simdutf-connector-static.dir\flb_simdutf_connector.cpp.obj.d --working-dir=D:\a\fluent-bit\fluent-bit\build\src\simdutf --filter-prefix="Note: including file: " -- C:\PROGRA~1\MICROS~2\2022\ENTERP~1\VC\Tools\MSVC\1443~1.348\bin\Hostx86\x86\cl.exe @C:\Users\RUNNER~1\AppData\Local\Temp\nm8B22.tmp' : return code '0x2'
Stop.
NMAKE : fatal error U1077: '"C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.43.34808\bin\HostX86\x86\nmake.exe" -s -f src\simdutf\CMakeFiles\flb-simdutf-connector-static.dir\build.make /nologo -SL                 src\simdutf\CMakeFiles\flb-simdutf-connector-static.dir\build' : return code '0x2'
Stop.
NMAKE : fatal error U1077: '"C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.43.34808\bin\HostX86\x86\nmake.exe" -s -f CMakeFiles\Makefile2 /nologo -LS                 all' : return code '0x2'
```

This could be fixed with this PR.