### PR TITLE
core: fix comment typo in mk_list_entry_last macro

### DIFF
--- a/include/monkey/mk_core/mk_list.h
+++ b/include/monkey/mk_core/mk_list.h
@@ -225,7 +225,7 @@ static inline void mk_list_cat(struct mk_list *list, struct mk_list *head)
  */
 #define mk_list_entry_first(ptr, type, member) container_of((ptr)->next, type, member)
 
-/* First node of the list
+/* Last node of the list
  * ---------------------
  * Be careful with this Macro, its intended to be used when some node is already linked
  * to the list (ptr). If the list is empty it will return the list address as it points


### PR DESCRIPTION
The comment incorrectly described the macro as returning the first node. 
Updated it to correctly state that it returns the last node.