### PR TITLE
core: event: add native windows backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,7 @@ option(MK_EVENT_LOOP_SELECT    "Use select(2) event loop" No)
 option(MK_EVENT_LOOP_POLL      "Use poll(2) event loop"   No)
 option(MK_EVENT_LOOP_KQUEUE    "Use kqueue(2) event loop" No)
 option(MK_EVENT_LOOP_EPOLL     "Use epoll(2) event loop"  No)
+option(MK_EVENT_LOOP_WIN32     "Use WinSock event loop"   No)
 option(MK_EVENT_LOOP_LIBEVENT  "Use libevent event loop"  No)
 
 # If building just for a "library" mode, disable plugins
@@ -292,15 +293,8 @@ include_directories(include/monkey/)
 include_directories(${CMAKE_CURRENT_BINARY_DIR}/include/)
 include_directories(${CMAKE_CURRENT_BINARY_DIR}/include/monkey/)
 
-# Check if we need to build libevent by using auto discovery mechanism
-if (CMAKE_SYSTEM_NAME MATCHES "Windows" AND
-    (
-      NOT MK_EVENT_LOOP_SELECT AND
-      NOT MK_EVENT_LOOP_POLL AND
-      NOT MK_EVENT_LOOP_KQUEUE AND
-      NOT MK_EVENT_LOOP_EPOLL
-    ) OR MK_EVENT_LOOP_LIBEVENT)
-
+# Check if we need to build libevent
+if (MK_EVENT_LOOP_LIBEVENT)
   set(MK_EVENT_LOOP_LIBEVENT Yes)
   include_directories(mk_core/deps/libevent/include)
   include_directories("${PROJECT_BINARY_DIR}/mk_core/deps/libevent/include/")

--- a/include/monkey/mk_core/mk_event.h
+++ b/include/monkey/mk_core/mk_event.h
@@ -78,6 +78,8 @@
     #include "mk_event_kqueue.h"
 #elif defined(MK_EVENT_LOOP_EPOLL)
     #include "mk_event_epoll.h"
+#elif defined(MK_EVENT_LOOP_WIN32)
+    #include "mk_event_win32.h"
 #elif defined(MK_EVENT_LOOP_LIBEVENT)
     #include "mk_event_libevent.h"
 #else
@@ -87,14 +89,14 @@
     #elif defined(__FreeBSD__) || defined(__APPLE__) || defined(__DragonFly__) || defined(__OpenBSD__)
         #include "mk_event_kqueue.h"
     #elif defined(_WIN32)
-        #include "mk_event_libevent.h"
+        #include "mk_event_win32.h"
     #else
         #include "mk_event_select.h"
     #endif
 #endif
 
 #if defined(_WIN32)
-    #define mk_event_closesocket(s) evutil_closesocket(s)
+    #define mk_event_closesocket(s) closesocket(s)
 #else
     #define mk_event_closesocket(s) close(s)
 #endif

--- a/include/monkey/mk_core/mk_event_win32.h
+++ b/include/monkey/mk_core/mk_event_win32.h
@@ -1,0 +1,48 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Monkey HTTP Server
+ *  ==================
+ *  Copyright 2001-2026 Eduardo Silva <eduardo@monkey.io>
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef MK_EVENT_WIN32_H
+#define MK_EVENT_WIN32_H
+
+#include <winsock2.h>
+#include <ws2tcpip.h>
+
+struct mk_event_ctx {
+    int queue_size;
+    struct mk_event **events;
+    struct mk_event **poll_events;
+    struct mk_event *fired;
+    WSAPOLLFD *pfds;
+};
+
+#define mk_event_foreach(event, evl)                                         \
+    int __i;                                                                 \
+    struct mk_event_ctx *__ctx = evl->data;                                  \
+                                                                             \
+    if (evl->n_events > 0) {                                                 \
+        event = __ctx->fired[0].data;                                        \
+    }                                                                        \
+                                                                             \
+    for (__i = 0;                                                            \
+         __i < evl->n_events;                                                \
+         __i++,                                                              \
+             event = ((__i < evl->n_events) ? __ctx->fired[__i].data : NULL) \
+         )
+
+#endif

--- a/mk_core/CMakeLists.txt
+++ b/mk_core/CMakeLists.txt
@@ -25,7 +25,9 @@ if (CMAKE_SYSTEM_NAME MATCHES "Windows")
     ${src}
     "external/winpthreads.c"
     )
-  add_subdirectory(deps/)
+  if (MK_EVENT_LOOP_LIBEVENT)
+    add_subdirectory(deps/)
+  endif()
 else()
   if (MK_EVENT_LOOP_LIBEVENT)
     add_subdirectory(deps/)
@@ -123,6 +125,15 @@ check_c_source_compiles("
      return epoll_create(1);
   }" HAVE_EPOLL)
 
+if (CMAKE_SYSTEM_NAME MATCHES "Windows" AND
+    NOT MK_EVENT_LOOP_SELECT AND
+    NOT MK_EVENT_LOOP_POLL AND
+    NOT MK_EVENT_LOOP_KQUEUE AND
+    NOT MK_EVENT_LOOP_EPOLL AND
+    NOT MK_EVENT_LOOP_LIBEVENT)
+  set(MK_EVENT_LOOP_WIN32 Yes)
+endif()
+
 if (MK_EVENT_LOOP_SELECT)
   if (NOT HAVE_SELECT)
     message(FATAL_ERROR "Event loop backend > select(2) not available")
@@ -156,6 +167,15 @@ if (MK_EVENT_LOOP_EPOLL)
   else()
     message(STATUS "Event loop backend > epoll(2)")
     MK_DEFINITION(MK_EVENT_LOOP_EPOLL)
+  endif()
+endif()
+
+if (MK_EVENT_LOOP_WIN32)
+  if (NOT CMAKE_SYSTEM_NAME MATCHES "Windows")
+    message(FATAL_ERROR "Event loop backend > win32 only available on Windows")
+  else()
+    message(STATUS "Event loop backend > win32")
+    MK_DEFINITION(MK_EVENT_LOOP_WIN32)
   endif()
 endif()
 
@@ -209,6 +229,10 @@ configure_file(
 
 add_library(mk_core STATIC ${src})
 target_link_libraries(mk_core ${CMAKE_THREAD_LIBS_INIT})
+
+if (CMAKE_SYSTEM_NAME MATCHES "Windows")
+  target_link_libraries(mk_core ws2_32)
+endif()
 
 if (MK_EVENT_LOOP_LIBEVENT)
   target_link_libraries(mk_core event)

--- a/mk_core/mk_event.c
+++ b/mk_core/mk_event.c
@@ -36,6 +36,8 @@
     #include "mk_event_kqueue.c"
 #elif defined(MK_EVENT_LOOP_EPOLL)
     #include "mk_event_epoll.c"
+#elif defined(MK_EVENT_LOOP_WIN32)
+    #include "mk_event_win32.c"
 #elif defined(MK_EVENT_LOOP_LIBEVENT)
     #include "mk_event_libevent.c"
 #else
@@ -45,7 +47,7 @@
     #elif defined(__FreeBSD__) || defined(__APPLE__) || defined(__DragonFly__) || defined(__OpenBSD__)
         #include "mk_event_kqueue.c"
     #elif defined(_WIN32)
-        #include "mk_event_libevent.c"
+        #include "mk_event_win32.c"
     #else
         #include "mk_event_select.c"
     #endif

--- a/mk_core/mk_event_win32.c
+++ b/mk_core/mk_event_win32.c
@@ -1,0 +1,567 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Monkey HTTP Server
+ *  ==================
+ *  Copyright 2001-2026 Eduardo Silva <eduardo@monkey.io>
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#include <windows.h>
+
+#include <mk_core/mk_event.h>
+
+struct win32_timer {
+    SOCKET read_fd;
+    SOCKET write_fd;
+    HANDLE timer;
+    HANDLE stop_event;
+    HANDLE thread;
+};
+
+static LONG win32_wsa_initialized = 0;
+
+static int win32_socketpair(SOCKET pair[2])
+{
+    int ret;
+    int one = 1;
+    int addrlen;
+    SOCKET listener = INVALID_SOCKET;
+    SOCKET client = INVALID_SOCKET;
+    SOCKET server = INVALID_SOCKET;
+    struct sockaddr_in addr;
+
+    listener = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+    if (listener == INVALID_SOCKET) {
+        return -1;
+    }
+
+    ret = setsockopt(listener, SOL_SOCKET, SO_REUSEADDR, (char *) &one, sizeof(one));
+    if (ret == SOCKET_ERROR) {
+        closesocket(listener);
+        return -1;
+    }
+
+    memset(&addr, 0, sizeof(addr));
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    addr.sin_port = 0;
+
+    ret = bind(listener, (struct sockaddr *) &addr, sizeof(addr));
+    if (ret == SOCKET_ERROR) {
+        closesocket(listener);
+        return -1;
+    }
+
+    ret = listen(listener, 1);
+    if (ret == SOCKET_ERROR) {
+        closesocket(listener);
+        return -1;
+    }
+
+    addrlen = sizeof(addr);
+    ret = getsockname(listener, (struct sockaddr *) &addr, &addrlen);
+    if (ret == SOCKET_ERROR) {
+        closesocket(listener);
+        return -1;
+    }
+
+    client = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+    if (client == INVALID_SOCKET) {
+        closesocket(listener);
+        return -1;
+    }
+
+    ret = connect(client, (struct sockaddr *) &addr, sizeof(addr));
+    if (ret == SOCKET_ERROR) {
+        closesocket(client);
+        closesocket(listener);
+        return -1;
+    }
+
+    server = accept(listener, NULL, NULL);
+    closesocket(listener);
+    if (server == INVALID_SOCKET) {
+        closesocket(client);
+        return -1;
+    }
+
+    pair[0] = server;
+    pair[1] = client;
+    return 0;
+}
+
+static inline int _mk_event_init()
+{
+    int ret;
+    WSADATA wsa_data;
+
+    if (InterlockedCompareExchange(&win32_wsa_initialized, 1, 0) != 0) {
+        return 0;
+    }
+
+    ret = WSAStartup(MAKEWORD(2, 2), &wsa_data);
+    if (ret != 0) {
+        InterlockedExchange(&win32_wsa_initialized, 0);
+        return -1;
+    }
+
+    return 0;
+}
+
+static inline void *_mk_event_loop_create(int size)
+{
+    struct mk_event_ctx *ctx;
+
+    if (_mk_event_init() != 0) {
+        return NULL;
+    }
+
+    ctx = mk_mem_alloc_z(sizeof(struct mk_event_ctx));
+    if (!ctx) {
+        return NULL;
+    }
+
+    ctx->events = mk_mem_alloc_z(sizeof(struct mk_event *) * size);
+    if (!ctx->events) {
+        mk_mem_free(ctx);
+        return NULL;
+    }
+
+    ctx->poll_events = mk_mem_alloc_z(sizeof(struct mk_event *) * size);
+    if (!ctx->poll_events) {
+        mk_mem_free(ctx->events);
+        mk_mem_free(ctx);
+        return NULL;
+    }
+
+    ctx->fired = mk_mem_alloc_z(sizeof(struct mk_event) * size);
+    if (!ctx->fired) {
+        mk_mem_free(ctx->poll_events);
+        mk_mem_free(ctx->events);
+        mk_mem_free(ctx);
+        return NULL;
+    }
+
+    ctx->pfds = mk_mem_alloc_z(sizeof(WSAPOLLFD) * size);
+    if (!ctx->pfds) {
+        mk_mem_free(ctx->fired);
+        mk_mem_free(ctx->poll_events);
+        mk_mem_free(ctx->events);
+        mk_mem_free(ctx);
+        return NULL;
+    }
+
+    ctx->queue_size = size;
+    return ctx;
+}
+
+static inline void _mk_event_loop_destroy(struct mk_event_ctx *ctx)
+{
+    mk_mem_free(ctx->pfds);
+    mk_mem_free(ctx->fired);
+    mk_mem_free(ctx->poll_events);
+    mk_mem_free(ctx->events);
+    mk_mem_free(ctx);
+}
+
+static inline int _mk_event_add(struct mk_event_ctx *ctx, int fd,
+                                int type, uint32_t events, void *data)
+{
+    int i;
+    int found = -1;
+    int empty = -1;
+    struct mk_event *event;
+
+    mk_bug(ctx == NULL);
+    mk_bug(data == NULL);
+
+    for (i = 0; i < ctx->queue_size; i++) {
+        if (ctx->events[i] == NULL) {
+            if (empty == -1) {
+                empty = i;
+            }
+            continue;
+        }
+
+        if (ctx->events[i]->fd == fd) {
+            found = i;
+            break;
+        }
+    }
+
+    if (found == -1) {
+        if (empty == -1) {
+            return -1;
+        }
+        found = empty;
+    }
+
+    event = (struct mk_event *) data;
+    ctx->events[found] = event;
+
+    if (event->mask == MK_EVENT_EMPTY) {
+        event->fd = fd;
+        event->status = MK_EVENT_REGISTERED;
+    }
+
+    event->mask = events;
+    if (type != MK_EVENT_UNMODIFIED) {
+        event->type = type;
+    }
+
+    event->priority = MK_EVENT_PRIORITY_DEFAULT;
+
+    if (!mk_list_entry_is_orphan(&event->_priority_head)) {
+        mk_list_del(&event->_priority_head);
+    }
+
+    return 0;
+}
+
+static inline int _mk_event_del(struct mk_event_ctx *ctx, struct mk_event *event)
+{
+    int i;
+
+    mk_bug(ctx == NULL);
+    mk_bug(event == NULL);
+
+    if (!MK_EVENT_IS_REGISTERED(event)) {
+        return 0;
+    }
+
+    for (i = 0; i < ctx->queue_size; i++) {
+        if (ctx->events[i] == event) {
+            ctx->events[i] = NULL;
+            break;
+        }
+    }
+
+    if (i == ctx->queue_size) {
+        return -1;
+    }
+
+    if (!mk_list_entry_is_orphan(&event->_priority_head)) {
+        mk_list_del(&event->_priority_head);
+    }
+
+    MK_EVENT_NEW(event);
+    return 0;
+}
+
+static DWORD WINAPI win32_timer_worker(LPVOID arg)
+{
+    DWORD ret;
+    uint64_t value = 1;
+    HANDLE handles[2];
+    struct win32_timer *timer = arg;
+
+    handles[0] = timer->stop_event;
+    handles[1] = timer->timer;
+
+    while (1) {
+        ret = WaitForMultipleObjects(2, handles, FALSE, INFINITE);
+        if (ret == WAIT_OBJECT_0) {
+            break;
+        }
+
+        if (ret != WAIT_OBJECT_0 + 1) {
+            break;
+        }
+
+        ret = send(timer->write_fd, (const char *) &value, sizeof(value), 0);
+        if (ret == SOCKET_ERROR) {
+            break;
+        }
+    }
+
+    return 0;
+}
+
+static inline int _mk_event_timeout_create(struct mk_event_ctx *ctx,
+                                           time_t sec, long nsec, void *data)
+{
+    int ret;
+    DWORD period_ms;
+    LARGE_INTEGER due_time;
+    SOCKET pair[2];
+    struct mk_event *event;
+    struct win32_timer *timer;
+
+    mk_bug(data == NULL);
+
+    if (win32_socketpair(pair) != 0) {
+        return -1;
+    }
+
+    timer = mk_mem_alloc_z(sizeof(struct win32_timer));
+    if (!timer) {
+        closesocket(pair[0]);
+        closesocket(pair[1]);
+        return -1;
+    }
+
+    period_ms = (DWORD) (sec * 1000);
+    if (nsec > 0) {
+        period_ms += (DWORD) ((nsec + 999999) / 1000000);
+    }
+    if (period_ms == 0) {
+        period_ms = 1;
+    }
+
+    timer->read_fd = pair[0];
+    timer->write_fd = pair[1];
+    timer->stop_event = CreateEvent(NULL, TRUE, FALSE, NULL);
+    timer->timer = CreateWaitableTimer(NULL, FALSE, NULL);
+
+    if (timer->stop_event == NULL || timer->timer == NULL) {
+        if (timer->stop_event != NULL) {
+            CloseHandle(timer->stop_event);
+        }
+        if (timer->timer != NULL) {
+            CloseHandle(timer->timer);
+        }
+        closesocket(pair[0]);
+        closesocket(pair[1]);
+        mk_mem_free(timer);
+        return -1;
+    }
+
+    due_time.QuadPart = -((LONGLONG) period_ms * 10000);
+    ret = SetWaitableTimer(timer->timer, &due_time, period_ms, NULL, NULL, FALSE);
+    if (ret == 0) {
+        CloseHandle(timer->timer);
+        CloseHandle(timer->stop_event);
+        closesocket(pair[0]);
+        closesocket(pair[1]);
+        mk_mem_free(timer);
+        return -1;
+    }
+
+    timer->thread = CreateThread(NULL, 0, win32_timer_worker, timer, 0, NULL);
+    if (timer->thread == NULL) {
+        CancelWaitableTimer(timer->timer);
+        CloseHandle(timer->timer);
+        CloseHandle(timer->stop_event);
+        closesocket(pair[0]);
+        closesocket(pair[1]);
+        mk_mem_free(timer);
+        return -1;
+    }
+
+    event = (struct mk_event *) data;
+    event->fd = (int) pair[0];
+    event->type = MK_EVENT_NOTIFICATION;
+    event->mask = MK_EVENT_EMPTY;
+    event->data = timer;
+
+    ret = _mk_event_add(ctx, event->fd, MK_EVENT_NOTIFICATION, MK_EVENT_READ, data);
+    if (ret != 0) {
+        SetEvent(timer->stop_event);
+        WaitForSingleObject(timer->thread, INFINITE);
+        CloseHandle(timer->thread);
+        CancelWaitableTimer(timer->timer);
+        CloseHandle(timer->timer);
+        CloseHandle(timer->stop_event);
+        closesocket(pair[0]);
+        closesocket(pair[1]);
+        mk_mem_free(timer);
+        return ret;
+    }
+
+    return event->fd;
+}
+
+static inline int _mk_event_timeout_destroy(struct mk_event_ctx *ctx, void *data)
+{
+    struct mk_event *event;
+    struct win32_timer *timer;
+
+    if (data == NULL) {
+        return 0;
+    }
+
+    event = (struct mk_event *) data;
+    timer = event->data;
+
+    _mk_event_del(ctx, event);
+
+    if (timer != NULL) {
+        SetEvent(timer->stop_event);
+        WaitForSingleObject(timer->thread, INFINITE);
+        CloseHandle(timer->thread);
+        CancelWaitableTimer(timer->timer);
+        CloseHandle(timer->timer);
+        CloseHandle(timer->stop_event);
+        closesocket(timer->read_fd);
+        closesocket(timer->write_fd);
+        mk_mem_free(timer);
+        event->data = NULL;
+    }
+
+    return 0;
+}
+
+static inline int _mk_event_channel_create(struct mk_event_ctx *ctx,
+                                           int *r_fd, int *w_fd, void *data)
+{
+    int ret;
+    SOCKET pair[2];
+    struct mk_event *event;
+
+    mk_bug(data == NULL);
+
+    if (win32_socketpair(pair) != 0) {
+        return -1;
+    }
+
+    event = (struct mk_event *) data;
+    event->fd = (int) pair[0];
+    event->type = MK_EVENT_NOTIFICATION;
+    event->mask = MK_EVENT_EMPTY;
+
+    ret = _mk_event_add(ctx, event->fd, MK_EVENT_NOTIFICATION, MK_EVENT_READ, event);
+    if (ret != 0) {
+        closesocket(pair[0]);
+        closesocket(pair[1]);
+        return ret;
+    }
+
+    *r_fd = (int) pair[0];
+    *w_fd = (int) pair[1];
+    return 0;
+}
+
+static inline int _mk_event_channel_destroy(struct mk_event_ctx *ctx,
+                                            int r_fd, int w_fd, void *data)
+{
+    struct mk_event *event;
+    int ret;
+
+    event = (struct mk_event *) data;
+    if (event->fd != r_fd) {
+        return -1;
+    }
+
+    ret = _mk_event_del(ctx, event);
+    closesocket((SOCKET) r_fd);
+    closesocket((SOCKET) w_fd);
+    return ret;
+}
+
+static inline int _mk_event_inject(struct mk_event_loop *loop,
+                                   struct mk_event *event,
+                                   int mask,
+                                   int prevent_duplication)
+{
+    int i;
+    struct mk_event_ctx *ctx;
+
+    ctx = loop->data;
+
+    if (prevent_duplication) {
+        for (i = 0; i < loop->n_events; i++) {
+            if (ctx->fired[i].data == event) {
+                return 0;
+            }
+        }
+    }
+
+    event->mask = mask;
+    ctx->fired[loop->n_events].data = event;
+    loop->n_events++;
+    return 0;
+}
+
+static inline int _mk_event_wait_2(struct mk_event_loop *loop, int timeout)
+{
+    int i;
+    int count = 0;
+    int fired = 0;
+    short events;
+    short revents;
+    uint32_t mask;
+    struct mk_event *event;
+    struct mk_event_ctx *ctx = loop->data;
+
+    loop->n_events = 0;
+
+    for (i = 0; i < ctx->queue_size; i++) {
+        event = ctx->events[i];
+        if (event == NULL) {
+            continue;
+        }
+
+        events = 0;
+        if (event->mask & MK_EVENT_READ) {
+            events |= POLLIN;
+        }
+        if (event->mask & MK_EVENT_WRITE) {
+            events |= POLLOUT;
+        }
+
+        ctx->pfds[count].fd = (SOCKET) event->fd;
+        ctx->pfds[count].events = events;
+        ctx->pfds[count].revents = 0;
+        ctx->poll_events[count] = event;
+        count++;
+    }
+
+    if (count == 0) {
+        if (timeout > 0) {
+            Sleep((DWORD) timeout);
+        }
+        return 0;
+    }
+
+    fired = WSAPoll(ctx->pfds, count, timeout);
+    if (fired <= 0) {
+        return fired;
+    }
+
+    for (i = 0; i < count; i++) {
+        revents = ctx->pfds[i].revents;
+        if (revents == 0) {
+            continue;
+        }
+
+        mask = 0;
+        if (revents & (POLLIN | POLLRDNORM | POLLRDBAND | POLLPRI)) {
+            mask |= MK_EVENT_READ;
+        }
+        if (revents & (POLLOUT | POLLWRNORM | POLLWRBAND)) {
+            mask |= MK_EVENT_WRITE;
+        }
+        if (revents & (POLLERR | POLLHUP | POLLNVAL)) {
+            mask |= MK_EVENT_CLOSE;
+        }
+
+        if (mask == 0) {
+            continue;
+        }
+
+        ctx->fired[loop->n_events].fd = ctx->poll_events[i]->fd;
+        ctx->fired[loop->n_events].mask = mask;
+        ctx->fired[loop->n_events].data = ctx->poll_events[i];
+        loop->n_events++;
+    }
+
+    return loop->n_events;
+}
+
+static inline char *_mk_event_backend()
+{
+    return "win32";
+}

--- a/mk_server/mk_fifo.c
+++ b/mk_server/mk_fifo.c
@@ -21,7 +21,76 @@
 #include <monkey/mk_scheduler.h>
 
 #ifdef _WIN32
-#include <event.h>
+static int mk_fifo_socketpair(mk_fifo_channel_fd channel[2])
+{
+    int ret;
+    int addr_len;
+    int one = 1;
+    SOCKET listener = INVALID_SOCKET;
+    SOCKET client = INVALID_SOCKET;
+    SOCKET server = INVALID_SOCKET;
+    struct sockaddr_in addr;
+
+    listener = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+    if (listener == INVALID_SOCKET) {
+        return -1;
+    }
+
+    ret = setsockopt(listener, SOL_SOCKET, SO_REUSEADDR,
+                     (const char *) &one, sizeof(one));
+    if (ret == SOCKET_ERROR) {
+        closesocket(listener);
+        return -1;
+    }
+
+    memset(&addr, 0, sizeof(addr));
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    addr.sin_port = 0;
+
+    ret = bind(listener, (struct sockaddr *) &addr, sizeof(addr));
+    if (ret == SOCKET_ERROR) {
+        closesocket(listener);
+        return -1;
+    }
+
+    ret = listen(listener, 1);
+    if (ret == SOCKET_ERROR) {
+        closesocket(listener);
+        return -1;
+    }
+
+    addr_len = sizeof(addr);
+    ret = getsockname(listener, (struct sockaddr *) &addr, &addr_len);
+    if (ret == SOCKET_ERROR) {
+        closesocket(listener);
+        return -1;
+    }
+
+    client = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+    if (client == INVALID_SOCKET) {
+        closesocket(listener);
+        return -1;
+    }
+
+    ret = connect(client, (struct sockaddr *) &addr, sizeof(addr));
+    if (ret == SOCKET_ERROR) {
+        closesocket(client);
+        closesocket(listener);
+        return -1;
+    }
+
+    server = accept(listener, NULL, NULL);
+    closesocket(listener);
+    if (server == INVALID_SOCKET) {
+        closesocket(client);
+        return -1;
+    }
+
+    channel[0] = (mk_fifo_channel_fd) server;
+    channel[1] = (mk_fifo_channel_fd) client;
+    return 0;
+}
 #endif
 
 static struct mk_fifo_worker *mk_fifo_worker_create(struct mk_fifo *ctx,
@@ -55,7 +124,7 @@ static struct mk_fifo_worker *mk_fifo_worker_create(struct mk_fifo *ctx,
     fw->buf_size = MK_FIFO_BUF_SIZE;
 
 #ifdef _WIN32
-    ret = evutil_socketpair(AF_INET, SOCK_STREAM, 0, fw->channel);
+    ret = mk_fifo_socketpair(fw->channel);
     if (ret == -1) {
         perror("socketpair");
         mk_mem_free(fw);
@@ -249,8 +318,8 @@ static int mk_fifo_worker_destroy_all(struct mk_fifo *ctx)
         fw = mk_list_entry(head, struct mk_fifo_worker, _head);
 
 #ifdef _WIN32
-        evutil_closesocket(fw->channel[0]);
-        evutil_closesocket(fw->channel[1]);
+        closesocket((SOCKET) fw->channel[0]);
+        closesocket((SOCKET) fw->channel[1]);
 #else
         close(fw->channel[0]);
         close(fw->channel[1]);

--- a/mk_server/monkey.c
+++ b/mk_server/monkey.c
@@ -31,7 +31,7 @@
 
 pthread_once_t mk_server_tls_setup_once = PTHREAD_ONCE_INIT;
 
-static void mk_set_up_tls_keys()
+static void mk_set_up_tls_keys(void)
 {
     MK_INIT_INITIALIZE_TLS_UNIVERSAL();
     MK_INIT_INITIALIZE_TLS();

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -8,6 +8,7 @@
 #              WORKING_DIRECTORY ${CMAKE_HOME_DIRECTORY}/build)
 # endif()
 set(UNIT_TESTS_FILES
+  event_loop.c
   lib_server.c
   event_timeout.c
   )

--- a/test/event_loop.c
+++ b/test/event_loop.c
@@ -1,0 +1,263 @@
+/*  Monkey HTTP Server
+ *  ==================
+ *  Copyright 2001-2026 Monkey Software LLC <eduardo@monkey.io>
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <monkey/mk_core.h>
+
+#ifdef _WIN32
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#else
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <unistd.h>
+#endif
+
+#include "mk_tests.h"
+
+static int write_signal(int fd, uint64_t value)
+{
+#ifdef _WIN32
+    return send((SOCKET) fd, (const char *) &value, sizeof(value), 0);
+#else
+    return write(fd, &value, sizeof(value));
+#endif
+}
+
+static int read_signal(int fd, uint64_t *value)
+{
+#ifdef _WIN32
+    return recv((SOCKET) fd, (char *) value, sizeof(*value), MSG_WAITALL);
+#else
+    return read(fd, value, sizeof(*value));
+#endif
+}
+
+static void close_fd(int fd)
+{
+    mk_event_closesocket(fd);
+}
+
+static int create_connected_pair(int pair[2])
+{
+    int ret;
+    int listener = -1;
+    int client = -1;
+    int server = -1;
+    socklen_t addrlen;
+    struct sockaddr_in addr;
+
+    listener = socket(AF_INET, SOCK_STREAM, 0);
+    if (listener < 0) {
+        return -1;
+    }
+
+    memset(&addr, 0, sizeof(addr));
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    addr.sin_port = 0;
+
+    ret = bind(listener, (struct sockaddr *) &addr, sizeof(addr));
+    if (ret < 0) {
+        close_fd(listener);
+        return -1;
+    }
+
+    ret = listen(listener, 1);
+    if (ret < 0) {
+        close_fd(listener);
+        return -1;
+    }
+
+    addrlen = sizeof(addr);
+    ret = getsockname(listener, (struct sockaddr *) &addr, &addrlen);
+    if (ret < 0) {
+        close_fd(listener);
+        return -1;
+    }
+
+    client = socket(AF_INET, SOCK_STREAM, 0);
+    if (client < 0) {
+        close_fd(listener);
+        return -1;
+    }
+
+    ret = connect(client, (struct sockaddr *) &addr, sizeof(addr));
+    if (ret < 0) {
+        close_fd(client);
+        close_fd(listener);
+        return -1;
+    }
+
+    server = accept(listener, NULL, NULL);
+    close_fd(listener);
+    if (server < 0) {
+        close_fd(client);
+        return -1;
+    }
+
+    pair[0] = server;
+    pair[1] = client;
+    return 0;
+}
+
+void test_event_channel_wait_destroy(void)
+{
+    int ret;
+    int channels[2];
+    uint64_t value = 42;
+    struct mk_event *event;
+    struct mk_event loop_event = {0};
+    struct mk_event_loop *loop;
+
+    TEST_CHECK(mk_event_init() == 0);
+
+    loop = mk_event_loop_create(8);
+    TEST_ASSERT(loop != NULL);
+
+    ret = mk_event_channel_create(loop, &channels[0], &channels[1], &loop_event);
+    TEST_ASSERT(ret == 0);
+
+    ret = write_signal(channels[1], value);
+    TEST_ASSERT(ret == sizeof(value));
+
+    ret = mk_event_wait_2(loop, 1000);
+    TEST_ASSERT(ret == 1);
+
+    event = NULL;
+    mk_event_foreach(event, loop) {
+        TEST_ASSERT(event == &loop_event);
+        TEST_ASSERT(event->fd == channels[0]);
+        TEST_ASSERT((event->mask & MK_EVENT_READ) != 0);
+        break;
+    }
+
+    value = 0;
+    ret = read_signal(channels[0], &value);
+    TEST_ASSERT(ret == sizeof(value));
+    TEST_ASSERT(value == 42);
+
+    ret = mk_event_channel_destroy(loop, channels[0], channels[1], &loop_event);
+    TEST_ASSERT(ret == 0);
+
+    mk_event_loop_destroy(loop);
+}
+
+void test_event_add_wait_del(void)
+{
+    int ret;
+    int pair[2];
+    uint64_t value = 7;
+    struct mk_event *fired;
+    struct mk_event event = {0};
+    struct mk_event_loop *loop;
+
+    TEST_CHECK(mk_event_init() == 0);
+
+    TEST_ASSERT(create_connected_pair(pair) == 0);
+
+    loop = mk_event_loop_create(8);
+    TEST_ASSERT(loop != NULL);
+
+    ret = mk_event_add(loop, pair[0], MK_EVENT_CUSTOM, MK_EVENT_READ, &event);
+    TEST_ASSERT(ret == 0);
+
+    ret = write_signal(pair[1], value);
+    TEST_ASSERT(ret == sizeof(value));
+
+    ret = mk_event_wait_2(loop, 1000);
+    TEST_ASSERT(ret == 1);
+
+    fired = NULL;
+    mk_event_foreach(fired, loop) {
+        TEST_ASSERT(fired == &event);
+        TEST_ASSERT((fired->mask & MK_EVENT_READ) != 0);
+        break;
+    }
+
+    value = 0;
+    ret = read_signal(pair[0], &value);
+    TEST_ASSERT(ret == sizeof(value));
+    TEST_ASSERT(value == 7);
+
+    ret = mk_event_del(loop, &event);
+    TEST_ASSERT(ret == 0);
+
+    value = 9;
+    ret = write_signal(pair[1], value);
+    TEST_ASSERT(ret == sizeof(value));
+
+    ret = mk_event_wait_2(loop, 50);
+    TEST_ASSERT(ret == 0);
+
+    value = 0;
+    ret = read_signal(pair[0], &value);
+    TEST_ASSERT(ret == sizeof(value));
+    TEST_ASSERT(value == 9);
+
+    close_fd(pair[0]);
+    close_fd(pair[1]);
+    mk_event_loop_destroy(loop);
+}
+
+void test_event_inject_prevent_duplication(void)
+{
+    int ret;
+    struct mk_event event = {0};
+    struct mk_event *fired;
+    struct mk_event_loop *loop;
+
+    loop = mk_event_loop_create(4);
+    TEST_ASSERT(loop != NULL);
+
+    ret = mk_event_inject(loop, &event, MK_EVENT_READ, MK_TRUE);
+    TEST_ASSERT(ret == 0);
+
+    ret = mk_event_inject(loop, &event, MK_EVENT_READ, MK_TRUE);
+    TEST_ASSERT(ret == 0);
+    TEST_ASSERT(loop->n_events == 1);
+
+    fired = NULL;
+    mk_event_foreach(fired, loop) {
+        TEST_ASSERT(fired == &event);
+        TEST_ASSERT((fired->mask & MK_EVENT_READ) != 0);
+        break;
+    }
+
+    mk_event_loop_destroy(loop);
+}
+
+void test_event_wait_timeout_empty(void)
+{
+    int ret;
+    struct mk_event_loop *loop;
+
+    loop = mk_event_loop_create(4);
+    TEST_ASSERT(loop != NULL);
+
+    ret = mk_event_wait_2(loop, 25);
+    TEST_ASSERT(ret == 0);
+
+    mk_event_loop_destroy(loop);
+}
+
+TEST_LIST = {
+    {"event_channel_wait_destroy", test_event_channel_wait_destroy},
+    {"event_add_wait_del", test_event_add_wait_del},
+    {"event_inject_prevent_duplication", test_event_inject_prevent_duplication},
+    {"event_wait_timeout_empty", test_event_wait_timeout_empty},
+    {NULL, NULL}
+};

--- a/test/event_timeout.c
+++ b/test/event_timeout.c
@@ -15,56 +15,56 @@
  *  limitations under the License.
  */
 
-#ifndef _WIN32
-#include <unistd.h>
-#include <sys/timerfd.h>
-#endif
-
-#include <monkey/mk_lib.h>
-#include <monkey/monkey.h>
+#include <monkey/mk_core.h>
 
 #include "mk_tests.h"
 
-static void consume_timer_tick(int fd) 
+static int consume_timer_tick(int fd, uint64_t *val)
 {
-    int ret;
-    uint64_t val;
 #ifdef _WIN32
-    ret = recv(fd, &val, sizeof(val), 0);
+    return recv(fd, (char *) val, sizeof(*val), MSG_WAITALL);
 #else
-    ret = read(fd, &val, sizeof(val));
+    return read(fd, val, sizeof(*val));
 #endif
-    TEST_ASSERT(ret >= 0);
 }
-
-#ifdef _WIN32
-static void check_timer_invalidated(int fd) 
-{
-}
-#else
-static void check_timer_invalidated(int fd) 
-{
-    struct itimerspec timer_spec;
-    TEST_ASSERT(timerfd_gettime(fd, &timer_spec) == -1);
-}
-#endif
 
 void test_timeout_tick_destroy(void)
 {
+    int ret;
     struct mk_event_loop *evl;
-    struct mk_event *ev;
+    struct mk_event *fired;
+    struct mk_event ev = {0};
+    uint64_t tick = 0;
     int fd;
     int timeout_interval = 1;
 
-    evl = mk_event_loop_create(1);
-    ev = mk_mem_alloc_z(sizeof(struct mk_event*));
-    fd = mk_event_timeout_create(evl, timeout_interval, 0, ev);
-    TEST_ASSERT(ev->fd == fd);
+    TEST_CHECK(mk_event_init() == 0);
 
-    consume_timer_tick(ev->fd);
-    mk_event_timeout_destroy(evl, ev);
+    evl = mk_event_loop_create(4);
+    TEST_ASSERT(evl != NULL);
 
-    check_timer_invalidated(fd);
+    fd = mk_event_timeout_create(evl, timeout_interval, 0, &ev);
+    TEST_ASSERT(fd >= 0);
+    TEST_ASSERT(ev.fd == fd);
+
+    ret = mk_event_wait_2(evl, 1500);
+    TEST_ASSERT(ret == 1);
+
+    fired = NULL;
+    mk_event_foreach(fired, evl) {
+        TEST_ASSERT(fired == &ev);
+        TEST_ASSERT((fired->mask & MK_EVENT_READ) != 0);
+        break;
+    }
+
+    ret = consume_timer_tick(ev.fd, &tick);
+    TEST_ASSERT(ret == sizeof(tick));
+    TEST_ASSERT(tick == 1);
+
+    ret = mk_event_timeout_destroy(evl, &ev);
+    TEST_ASSERT(ret == 0);
+
+    mk_event_loop_destroy(evl);
 }
 
 TEST_LIST = {


### PR DESCRIPTION
 - Added a native Windows event loop backend for mk_event
  - Kept the existing mk_event interface behavior for:
      - readable sockets
      - notification channels
      - timer events
      - injected events
  - Updated build selection so:
      - Windows now defaults to the native backend
      - libevent is only built when explicitly requested

  ## Tests Added

  Added unit coverage for the public event loop interface, including:

  - channel notification delivery
  - add / wait / delete flow
  - duplicate-safe event injection
  - timeout delivery

  ## Verification

  cmake -S . -B build -DMK_TESTS=ON
  cmake --build build
  ./build/bin/mk-test-event_loop
  ./build/bin/mk-test-event_timeout
  ./build/bin/mk-test-lib_server