### PR TITLE
server: http: escape reflected uri content in html pages

### DIFF
--- a/include/monkey/mk_core/mk_string.h
+++ b/include/monkey/mk_core/mk_string.h
@@ -76,6 +76,7 @@ void mk_string_split_free(struct mk_list *list);
 int mk_string_trim(char **str);
 char *mk_string_build(char **buffer, unsigned long *len,
                       const char *format, ...) PRINTF_WARNINGS(3,4);
+char *mk_string_html_escape(const char *str);
 
 #if defined (__GNUC__) || defined (_WIN32)
 int mk_string_itop(uint64_t value, mk_ptr_t *p);

--- a/integration_tests/tests/test_network_layer.py
+++ b/integration_tests/tests/test_network_layer.py
@@ -76,6 +76,18 @@ def test_server_header_present(monkey_instance: MonkeyManager):
     assert headers["server"].startswith("Monkey/")
 
 
+def test_forbidden_error_page_escapes_reflected_uri(monkey_instance: MonkeyManager):
+    payload = b"GET /../\"><script>alert(73541);</script> HTTP/1.1\r\n"
+    payload += f"Host: {monkey_instance.host}:{monkey_instance.port}\r\n".encode()
+    payload += b"Connection: close\r\n\r\n"
+
+    response = monkey_instance.raw_request(payload)
+
+    assert b"HTTP/1.1 403 Forbidden" in response
+    assert b"<script>alert(73541);</script>" not in response
+    assert b"/../&quot;&gt;&lt;script&gt;alert(73541);&lt;/script&gt;" in response
+
+
 def test_server_restarts_cleanly():
     for candidate in selected_binaries():
         manager = MonkeyManager(resolve_binary(candidate), tls=candidate.tls)

--- a/mk_core/mk_string.c
+++ b/mk_core/mk_string.c
@@ -450,6 +450,76 @@ char *mk_string_build(char **buffer, unsigned long *len,
     return *buffer;
 }
 
+char *mk_string_html_escape(const char *str)
+{
+    size_t i;
+    size_t escaped_len = 0;
+    char *buf;
+    char *p;
+    const char *escape;
+
+    if (!str) {
+        return mk_string_dup("");
+    }
+
+    for (i = 0; str[i] != '\0'; i++) {
+        switch (str[i]) {
+        case '<':
+        case '>':
+            escaped_len += 4;
+            break;
+        case '&':
+            escaped_len += 5;
+            break;
+        case '"':
+        case '\'':
+            escaped_len += 6;
+            break;
+        default:
+            escaped_len++;
+        }
+    }
+
+    buf = mk_mem_alloc(escaped_len + 1);
+    if (!buf) {
+        return NULL;
+    }
+
+    p = buf;
+    for (i = 0; str[i] != '\0'; i++) {
+        escape = NULL;
+
+        switch (str[i]) {
+        case '<':
+            escape = "&lt;";
+            break;
+        case '>':
+            escape = "&gt;";
+            break;
+        case '&':
+            escape = "&amp;";
+            break;
+        case '"':
+            escape = "&quot;";
+            break;
+        case '\'':
+            escape = "&#039;";
+            break;
+        }
+
+        if (escape) {
+            strcpy(p, escape);
+            p += strlen(escape);
+        }
+        else {
+            *p++ = str[i];
+        }
+    }
+
+    *p = '\0';
+    return buf;
+}
+
 int mk_string_trim(char **str)
 {
     unsigned int i;

--- a/mk_server/mk_http.c
+++ b/mk_server/mk_http.c
@@ -384,6 +384,7 @@ static int mk_http_error_page(char *title, mk_ptr_t *message, char *signature,
                               char **out_buf, unsigned long *out_size)
 {
     char *temp;
+    char *escaped;
 
     *out_buf = NULL;
 
@@ -394,9 +395,19 @@ static int mk_http_error_page(char *title, mk_ptr_t *message, char *signature,
         temp = mk_string_dup("");
     }
 
-    mk_string_build(out_buf, out_size,
-                    MK_REQUEST_DEFAULT_PAGE, title, temp, signature);
+    if (!temp) {
+        return -1;
+    }
+
+    escaped = mk_string_html_escape(temp);
     mk_mem_free(temp);
+    if (!escaped) {
+        return -1;
+    }
+
+    mk_string_build(out_buf, out_size,
+                    MK_REQUEST_DEFAULT_PAGE, title, escaped, signature);
+    mk_mem_free(escaped);
     return 0;
 }
 

--- a/plugins/dirlisting/dirlisting.c
+++ b/plugins/dirlisting/dirlisting.c
@@ -476,6 +476,7 @@ struct dirhtml_value *mk_dirhtml_tag_assign(struct mk_list *list,
     aux->value = value;
     aux->sep = sep;
     aux->tags = tags;
+    aux->owned = MK_FALSE;
 
     if (value) {
         aux->len = strlen(value);
@@ -497,6 +498,9 @@ static void mk_dirhtml_tag_free_list(struct mk_list *list)
     mk_list_foreach_safe(head, tmp, list) {
         target = mk_list_entry(head, struct dirhtml_value, _head);
         mk_list_del(&target->_head);
+        if (target->owned == MK_TRUE && target->value) {
+            mk_api->mem_free(target->value);
+        }
         mk_api->mem_free(target);
     }
 }
@@ -741,11 +745,13 @@ static int mk_dirhtml_init(struct mk_plugin *plugin,
     int len;
     char tmp[16];
     unsigned int i = 0;
+    char *escaped_uri;
     struct mk_list *head;
     struct mk_list list;
     struct mk_f_list *entry;
     struct mk_dirhtml_request *request;
     struct mk_stream *stream;
+    struct dirhtml_value *title;
 
     if (!(dir = opendir(sr->real_path.data))) {
         return -1;
@@ -802,9 +808,24 @@ static int mk_dirhtml_init(struct mk_plugin *plugin,
     mk_list_init(&list);
 
     /* Set %_html_title_% */
-    mk_dirhtml_tag_assign(&list, 0, mk_dir_iov_none,
-                          sr->uri_processed.data,
-                          (char **) _tags_global);
+    escaped_uri = mk_string_html_escape(sr->uri_processed.data);
+    if (!escaped_uri) {
+        mk_stream_release(stream);
+        closedir(dir);
+        mk_api->mem_free(request);
+        return -1;
+    }
+    title = mk_dirhtml_tag_assign(&list, 0, mk_dir_iov_none,
+                                  escaped_uri,
+                                  (char **) _tags_global);
+    if (!title) {
+        mk_api->mem_free(escaped_uri);
+        mk_stream_release(stream);
+        closedir(dir);
+        mk_api->mem_free(request);
+        return -1;
+    }
+    title->owned = MK_TRUE;
 
     /* Set %_theme_path_% */
     mk_dirhtml_tag_assign(&list, 1, mk_dir_iov_none,

--- a/plugins/dirlisting/dirlisting.h
+++ b/plugins/dirlisting/dirlisting.h
@@ -142,6 +142,7 @@ struct dirhtml_value
 
     /* string data */
     int len;
+    int owned;
     char *value;
 
     /* next node */


### PR DESCRIPTION
Monkey rejected traversal requests containing '..', but the built-in HTML error page still reflected the original request URI without escaping. That allowed payloads such as /../"><script>...</script> to land in the response body as executable markup.

Add a reusable HTML escaping helper in mk_core and use it when building error pages. Apply the same escaping to dirlisting's HTML title path so URI-derived plugin output does not reintroduce the same issue.

Add a Python integration test that sends the raw forbidden request and asserts the response remains a 403 while the reflected URI is escaped.

Verified with:
- cmake --build build
- integration_tests/run_tests.py ... -k forbidden_error_page_escapes_reflected_uri
- curl --path-as-is against the rebuilt server