### PR TITLE
core: fifo: event: Implement native Windows socket pair

### DIFF
--- a/.github/workflows/build-pr.yaml
+++ b/.github/workflows/build-pr.yaml
@@ -20,10 +20,12 @@ jobs:
             arch: x64
             cmake_additional_opt: ""
             os: windows-latest
+            cmake_version: "3.31.6"
           - name: "Windows 64bit (ARM)"
             arch: amd64_arm64
             cmake_additional_opt: "-G \"NMake Makefiles\" -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_SYSTEM_VERSION=10.0 -DCMAKE_SYSTEM_PROCESSOR=ARM64 -DMK_TLS_BACKEND=mbedtls"
             os: windows-latest
+            cmake_version: "3.31.6"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -34,6 +36,83 @@ jobs:
         uses: ilammy/msvc-dev-cmd@v1
         with:
           arch: ${{ matrix.config.arch }}
+
+      - name: Set up CMake
+        run: |
+          $cmakeVersion = "${{ matrix.config.cmake_version }}"
+          $cmakeArch = "x86_64"
+          $cmakeUrl = "https://github.com/Kitware/CMake/releases/download/v${cmakeVersion}/cmake-${cmakeVersion}-windows-${cmakeArch}.zip"
+          $cmakeZip = "$env:RUNNER_TEMP\cmake-${cmakeVersion}.zip"
+          $cmakeDir = "C:\Program Files\CMake"
+
+          Write-Host "Downloading CMake ${cmakeVersion} from official GitHub releases: ${cmakeUrl}"
+
+          # Download with retry logic
+          $maxRetries = 3
+          $retryCount = 0
+          $downloaded = $false
+
+          while ($retryCount -lt $maxRetries -and -not $downloaded) {
+            try {
+              $retryCount++
+              Write-Host "Attempt $retryCount of $maxRetries"
+              Invoke-WebRequest -Uri $cmakeUrl -OutFile $cmakeZip -UseBasicParsing -ErrorAction Stop
+
+              # Verify file was downloaded and has content
+              if (Test-Path $cmakeZip) {
+                $fileInfo = Get-Item $cmakeZip
+                if ($fileInfo.Length -gt 0) {
+                  Write-Host "Download successful. File size: $($fileInfo.Length) bytes"
+                  $downloaded = $true
+                } else {
+                  Write-Host "Downloaded file is empty, retrying..."
+                  Remove-Item $cmakeZip -Force -ErrorAction SilentlyContinue
+                }
+              }
+            } catch {
+              Write-Host "Download attempt $retryCount failed: $_"
+              if ($retryCount -lt $maxRetries) {
+                Start-Sleep -Seconds 2
+                Remove-Item $cmakeZip -Force -ErrorAction SilentlyContinue
+              } else {
+                throw "Failed to download CMake after $maxRetries attempts: $_"
+              }
+            }
+          }
+
+          # Verify it's a valid ZIP file by checking the header (ZIP files start with PK)
+          $header = [System.IO.File]::ReadAllBytes($cmakeZip)[0..1]
+          if (-not ($header[0] -eq 0x50 -and $header[1] -eq 0x4B)) {
+            Write-Host "Warning: File may not be a valid ZIP. First bytes: $($header[0]), $($header[1])"
+            Write-Host "Expected: 80, 75 (PK in hex)"
+            throw "Downloaded file is not a valid ZIP archive"
+          }
+          Write-Host "ZIP file validation passed (PK header found)"
+
+          Write-Host "Extracting CMake to C:\Program Files"
+          # Remove existing CMake directory if it exists
+          if (Test-Path $cmakeDir) {
+            Remove-Item $cmakeDir -Recurse -Force
+          }
+
+          # Extract ZIP file
+          Expand-Archive -Path $cmakeZip -DestinationPath "C:\Program Files" -Force
+
+          # Rename extracted folder to standard CMake directory name
+          $extractedDir = "C:\Program Files\cmake-${cmakeVersion}-windows-${cmakeArch}"
+          if (Test-Path $extractedDir) {
+            Rename-Item -Path $extractedDir -NewName "CMake" -Force
+          }
+
+          # Verify installation
+          $cmakeExe = "$cmakeDir\bin\cmake.exe"
+          if (Test-Path $cmakeExe) {
+            Write-Host "CMake installed successfully"
+            & $cmakeExe --version
+          } else {
+            throw "CMake installation verification failed: $cmakeExe not found"
+          }
+        shell: pwsh
 
       - name: Build on ${{ matrix.os }} with vs-2019
         run: |

--- a/include/monkey/mk_core/mk_win32_socketpair.h
+++ b/include/monkey/mk_core/mk_win32_socketpair.h
@@ -1,0 +1,30 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Monkey HTTP Server
+ *  ==================
+ *  Copyright 2001-2026 Eduardo Silva <eduardo@monkey.io>
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef MK_WIN32_SOCKETPAIR_H
+#define MK_WIN32_SOCKETPAIR_H
+
+#ifdef _WIN32
+#include <winsock2.h>
+#include <ws2tcpip.h>
+
+int mk_win32_socketpair(SOCKET pair[2]);
+#endif
+
+#endif

--- a/mk_core/CMakeLists.txt
+++ b/mk_core/CMakeLists.txt
@@ -24,6 +24,7 @@ if (CMAKE_SYSTEM_NAME MATCHES "Windows")
   set(src
     ${src}
     "external/winpthreads.c"
+    "mk_win32_socketpair.c"
     )
   add_subdirectory(deps/)
 else()
@@ -123,6 +124,21 @@ check_c_source_compiles("
      return epoll_create(1);
   }" HAVE_EPOLL)
 
+if (CMAKE_SYSTEM_NAME MATCHES "Windows")
+  check_c_source_compiles("
+    #include <winsock2.h>
+    #include <afunix.h>
+    int main() {
+       struct sockaddr_un addr;
+       addr.sun_family = AF_UNIX;
+       return 0;
+    }" MK_HAVE_AFUNIX_H)
+
+  if (MK_HAVE_AFUNIX_H)
+    MK_DEFINITION(MK_HAVE_AFUNIX_H)
+  endif()
+endif()
+
 if (MK_EVENT_LOOP_SELECT)
   if (NOT HAVE_SELECT)
     message(FATAL_ERROR "Event loop backend > select(2) not available")
@@ -209,6 +225,10 @@ configure_file(
 
 add_library(mk_core STATIC ${src})
 target_link_libraries(mk_core ${CMAKE_THREAD_LIBS_INIT})
+
+if (CMAKE_SYSTEM_NAME MATCHES "Windows")
+  target_link_libraries(mk_core ws2_32)
+endif()
 
 if (MK_EVENT_LOOP_LIBEVENT)
   target_link_libraries(mk_core event)

--- a/mk_core/mk_event_libevent.c
+++ b/mk_core/mk_event_libevent.c
@@ -19,12 +19,16 @@
 
 
 #include <mk_core/mk_event.h>
+#ifdef _WIN32
+#include <mk_core/mk_win32_socketpair.h>
+#endif
 
 /* Libevent */
 #include <event.h>
 
 #ifdef _WIN32
 #define ERR(e) (WSA##e)
+static LONG mk_event_libevent_wsa_initialized = 0;
 #else
 #define ERR(e) (e)
 #endif
@@ -37,14 +41,54 @@ struct ev_map {
     struct mk_event_ctx *ctx;
 };
 
+static int mk_event_libevent_socketpair(evutil_socket_t fd[2])
+{
+#ifdef _WIN32
+    int ret;
+    SOCKET pair[2];
+
+    ret = mk_win32_socketpair(pair);
+    if (ret != 0) {
+        return ret;
+    }
+
+    fd[0] = (evutil_socket_t) pair[0];
+    fd[1] = (evutil_socket_t) pair[1];
+    return 0;
+#else
+    return evutil_socketpair(AF_UNIX, SOCK_STREAM, 0, fd);
+#endif
+}
+
 static inline int _mk_event_init()
 {
+#ifdef _WIN32
+    int ret;
+    WSADATA wsa_data;
+
+    if (InterlockedCompareExchange(&mk_event_libevent_wsa_initialized,
+                                   1, 0) != 0) {
+        return 0;
+    }
+
+    ret = WSAStartup(MAKEWORD(2, 2), &wsa_data);
+    if (ret != 0) {
+        InterlockedExchange(&mk_event_libevent_wsa_initialized, 0);
+        WSASetLastError(ret);
+        return -1;
+    }
+#endif
+
     return 0;
 }
 
 static inline void *_mk_event_loop_create(int size)
 {
     struct mk_event_ctx *ctx;
+
+    if (_mk_event_init() != 0) {
+        return NULL;
+    }
 
     /* Main event context */
     ctx = mk_mem_alloc_z(sizeof(struct mk_event_ctx));
@@ -300,7 +344,7 @@ static inline int _mk_event_timeout_create(struct mk_event_ctx *ctx,
 
     mk_bug(data == NULL);
 
-    if (evutil_socketpair(AF_UNIX, SOCK_STREAM, 0, fd) == -1) {
+    if (mk_event_libevent_socketpair(fd) == -1) {
         perror("socketpair");
         return -1;
     }
@@ -364,7 +408,7 @@ static inline int _mk_event_channel_create(struct mk_event_ctx *ctx,
 
     mk_bug(data == NULL);
 
-    ret = evutil_socketpair(AF_UNIX, SOCK_STREAM, 0, fd);
+    ret = mk_event_libevent_socketpair(fd);
 
     if (ret == -1) {
         perror("socketpair");

--- a/mk_core/mk_win32_socketpair.c
+++ b/mk_core/mk_win32_socketpair.c
@@ -1,0 +1,276 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Monkey HTTP Server
+ *  ==================
+ *  Copyright 2001-2026 Eduardo Silva <eduardo@monkey.io>
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifdef _WIN32
+
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#ifdef MK_HAVE_AFUNIX_H
+#include <afunix.h>
+#endif
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#undef WIN32_LEAN_AND_MEAN
+
+#include <string.h>
+
+#include <mk_core/mk_core_info.h>
+#include <mk_core/mk_win32_socketpair.h>
+
+static LONG mk_win32_wsa_initialized = 0;
+
+static int mk_win32_socketpair_init(void)
+{
+    int ret;
+    WSADATA wsa_data;
+
+    if (InterlockedCompareExchange(&mk_win32_wsa_initialized, 1, 0) != 0) {
+        return 0;
+    }
+
+    ret = WSAStartup(MAKEWORD(2, 2), &wsa_data);
+    if (ret != 0) {
+        InterlockedExchange(&mk_win32_wsa_initialized, 0);
+        WSASetLastError(ret);
+        return -1;
+    }
+
+    return 0;
+}
+
+#ifdef MK_HAVE_AFUNIX_H
+static int mk_win32_afunix_supported = -1;
+
+static int mk_win32_create_temp_path(char path[MAX_PATH])
+{
+    char short_path[MAX_PATH] = {0};
+    char long_path[MAX_PATH] = {0};
+
+    if (GetTempPathA(MAX_PATH, short_path) == 0) {
+        return -1;
+    }
+
+    if (GetLongPathNameA(short_path, long_path, MAX_PATH) == 0) {
+        strncpy(long_path, short_path, sizeof(long_path) - 1);
+    }
+
+    if (GetTempFileNameA(long_path, "mk", 0, path) == 0) {
+        return -1;
+    }
+
+    DeleteFileA(path);
+    return 0;
+}
+
+static int mk_win32_check_afunix(void)
+{
+    SOCKET fd;
+
+    if (mk_win32_afunix_supported >= 0) {
+        return mk_win32_afunix_supported;
+    }
+
+    fd = socket(AF_UNIX, SOCK_STREAM, 0);
+    if (fd == INVALID_SOCKET) {
+        mk_win32_afunix_supported = 0;
+        return 0;
+    }
+
+    closesocket(fd);
+    mk_win32_afunix_supported = 1;
+    return 1;
+}
+
+static int mk_win32_socketpair_afunix(SOCKET pair[2])
+{
+    int ret;
+    int path_len;
+    int addr_len;
+    SOCKET listener = INVALID_SOCKET;
+    SOCKET client = INVALID_SOCKET;
+    SOCKET server = INVALID_SOCKET;
+    struct sockaddr_un addr;
+    char path[MAX_PATH] = {0};
+
+    if (mk_win32_create_temp_path(path) != 0) {
+        return -1;
+    }
+
+    path_len = (int) strlen(path);
+    if (path_len >= (int) sizeof(addr.sun_path)) {
+        DeleteFileA(path);
+        WSASetLastError(WSAEINVAL);
+        return -1;
+    }
+
+    listener = socket(AF_UNIX, SOCK_STREAM, 0);
+    if (listener == INVALID_SOCKET) {
+        DeleteFileA(path);
+        return -1;
+    }
+
+    memset(&addr, 0, sizeof(addr));
+    addr.sun_family = AF_UNIX;
+    memcpy(addr.sun_path, path, path_len + 1);
+
+    ret = bind(listener, (struct sockaddr *) &addr, sizeof(addr));
+    if (ret == SOCKET_ERROR) {
+        goto error;
+    }
+
+    ret = listen(listener, 1);
+    if (ret == SOCKET_ERROR) {
+        goto error;
+    }
+
+    client = socket(AF_UNIX, SOCK_STREAM, 0);
+    if (client == INVALID_SOCKET) {
+        goto error;
+    }
+
+    addr_len = sizeof(addr);
+    ret = getsockname(listener, (struct sockaddr *) &addr, &addr_len);
+    if (ret == SOCKET_ERROR) {
+        goto error;
+    }
+
+    ret = connect(client, (struct sockaddr *) &addr, addr_len);
+    if (ret == SOCKET_ERROR) {
+        goto error;
+    }
+
+    server = accept(listener, NULL, NULL);
+    if (server == INVALID_SOCKET) {
+        goto error;
+    }
+
+    closesocket(listener);
+    DeleteFileA(path);
+
+    pair[0] = server;
+    pair[1] = client;
+    return 0;
+
+error:
+    if (listener != INVALID_SOCKET) {
+        closesocket(listener);
+    }
+    if (client != INVALID_SOCKET) {
+        closesocket(client);
+    }
+    if (server != INVALID_SOCKET) {
+        closesocket(server);
+    }
+    DeleteFileA(path);
+    return -1;
+}
+#endif
+
+static int mk_win32_socketpair_loopback(SOCKET pair[2])
+{
+    int ret;
+    int one = 1;
+    int addr_len;
+    SOCKET listener = INVALID_SOCKET;
+    SOCKET client = INVALID_SOCKET;
+    SOCKET server = INVALID_SOCKET;
+    struct sockaddr_in addr;
+
+    listener = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+    if (listener == INVALID_SOCKET) {
+        return -1;
+    }
+
+    ret = setsockopt(listener, SOL_SOCKET, SO_REUSEADDR,
+                     (const char *) &one, sizeof(one));
+    if (ret == SOCKET_ERROR) {
+        closesocket(listener);
+        return -1;
+    }
+
+    memset(&addr, 0, sizeof(addr));
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    addr.sin_port = 0;
+
+    ret = bind(listener, (struct sockaddr *) &addr, sizeof(addr));
+    if (ret == SOCKET_ERROR) {
+        closesocket(listener);
+        return -1;
+    }
+
+    ret = listen(listener, 1);
+    if (ret == SOCKET_ERROR) {
+        closesocket(listener);
+        return -1;
+    }
+
+    addr_len = sizeof(addr);
+    ret = getsockname(listener, (struct sockaddr *) &addr, &addr_len);
+    if (ret == SOCKET_ERROR) {
+        closesocket(listener);
+        return -1;
+    }
+
+    client = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+    if (client == INVALID_SOCKET) {
+        closesocket(listener);
+        return -1;
+    }
+
+    ret = connect(client, (struct sockaddr *) &addr, sizeof(addr));
+    if (ret == SOCKET_ERROR) {
+        closesocket(client);
+        closesocket(listener);
+        return -1;
+    }
+
+    server = accept(listener, NULL, NULL);
+    closesocket(listener);
+    if (server == INVALID_SOCKET) {
+        closesocket(client);
+        return -1;
+    }
+
+    pair[0] = server;
+    pair[1] = client;
+    return 0;
+}
+
+int mk_win32_socketpair(SOCKET pair[2])
+{
+    if (pair == NULL) {
+        WSASetLastError(WSAEINVAL);
+        return -1;
+    }
+
+    if (mk_win32_socketpair_init() != 0) {
+        return -1;
+    }
+
+#ifdef MK_HAVE_AFUNIX_H
+    if (mk_win32_check_afunix() && mk_win32_socketpair_afunix(pair) == 0) {
+        return 0;
+    }
+#endif
+
+    return mk_win32_socketpair_loopback(pair);
+}
+
+#endif

--- a/mk_server/mk_fifo.c
+++ b/mk_server/mk_fifo.c
@@ -21,7 +21,7 @@
 #include <monkey/mk_scheduler.h>
 
 #ifdef _WIN32
-#include <event.h>
+#include <mk_core/mk_win32_socketpair.h>
 #endif
 
 static struct mk_fifo_worker *mk_fifo_worker_create(struct mk_fifo *ctx,
@@ -30,6 +30,9 @@ static struct mk_fifo_worker *mk_fifo_worker_create(struct mk_fifo *ctx,
     int id;
     int ret;
     struct mk_fifo_worker *fw;
+#ifdef _WIN32
+    SOCKET channel[2];
+#endif
 
     /* Get an ID */
     id = mk_list_size(&ctx->workers);
@@ -55,9 +58,14 @@ static struct mk_fifo_worker *mk_fifo_worker_create(struct mk_fifo *ctx,
     fw->buf_size = MK_FIFO_BUF_SIZE;
 
 #ifdef _WIN32
-    ret = evutil_socketpair(AF_INET, SOCK_STREAM, 0, fw->channel);
+    ret = mk_win32_socketpair(channel);
+    if (ret == 0) {
+        fw->channel[0] = (mk_fifo_channel_fd) channel[0];
+        fw->channel[1] = (mk_fifo_channel_fd) channel[1];
+    }
     if (ret == -1) {
         perror("socketpair");
+        mk_mem_free(fw->buf_data);
         mk_mem_free(fw);
         return NULL;
     }
@@ -65,6 +73,7 @@ static struct mk_fifo_worker *mk_fifo_worker_create(struct mk_fifo *ctx,
     ret = pipe(fw->channel);
     if (ret == -1) {
         perror("pipe");
+        mk_mem_free(fw->buf_data);
         mk_mem_free(fw);
         return NULL;
     }
@@ -249,8 +258,8 @@ static int mk_fifo_worker_destroy_all(struct mk_fifo *ctx)
         fw = mk_list_entry(head, struct mk_fifo_worker, _head);
 
 #ifdef _WIN32
-        evutil_closesocket(fw->channel[0]);
-        evutil_closesocket(fw->channel[1]);
+        closesocket((SOCKET) fw->channel[0]);
+        closesocket((SOCKET) fw->channel[1]);
 #else
         close(fw->channel[0]);
         close(fw->channel[1]);
@@ -264,14 +273,14 @@ static int mk_fifo_worker_destroy_all(struct mk_fifo *ctx)
     return c;
 }
 
-static int msg_write(int fd, void *buf, size_t count)
+static int msg_write(mk_fifo_channel_fd fd, void *buf, size_t count)
 {
     ssize_t bytes;
     size_t total = 0;
 
     do {
 #ifdef _WIN32
-        bytes = send(fd, (uint8_t *)buf + total, count - total, 0);
+        bytes = send((SOCKET) fd, (uint8_t *)buf + total, count - total, 0);
 #else
         bytes = write(fd, (uint8_t *)buf + total, count - total);
 #endif
@@ -410,7 +419,8 @@ int mk_fifo_worker_read(void *event)
 
     /* Read data from pipe */
 #ifdef _WIN32
-    bytes = recv(fw->channel[0], fw->buf_data + fw->buf_len, available, 0);
+    bytes = recv((SOCKET) fw->channel[0],
+                 fw->buf_data + fw->buf_len, available, 0);
 #else
     bytes = read(fw->channel[0], fw->buf_data + fw->buf_len, available);
 #endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,6 +12,13 @@ set(UNIT_TESTS_FILES
   event_timeout.c
   )
 
+if (CMAKE_SYSTEM_NAME MATCHES "Windows")
+  set(UNIT_TESTS_FILES
+    ${UNIT_TESTS_FILES}
+    win32_socketpair.c
+    )
+endif()
+
 # Prepare list of unit tests
 foreach(source_file ${UNIT_TESTS_FILES})
   get_filename_component(source_file_we ${source_file} NAME_WE)

--- a/test/event_timeout.c
+++ b/test/event_timeout.c
@@ -15,56 +15,60 @@
  *  limitations under the License.
  */
 
-#ifndef _WIN32
-#include <unistd.h>
-#include <sys/timerfd.h>
-#endif
-
-#include <monkey/mk_lib.h>
-#include <monkey/monkey.h>
+#include <monkey/mk_core.h>
 
 #include "mk_tests.h"
 
-static void consume_timer_tick(int fd) 
+static int consume_timer_tick(int fd, uint64_t *val)
 {
-    int ret;
-    uint64_t val;
 #ifdef _WIN32
-    ret = recv(fd, &val, sizeof(val), 0);
+    return recv(fd, (char *) val, sizeof(*val), MSG_WAITALL);
 #else
-    ret = read(fd, &val, sizeof(val));
+    return read(fd, val, sizeof(*val));
 #endif
-    TEST_ASSERT(ret >= 0);
 }
-
-#ifdef _WIN32
-static void check_timer_invalidated(int fd) 
-{
-}
-#else
-static void check_timer_invalidated(int fd) 
-{
-    struct itimerspec timer_spec;
-    TEST_ASSERT(timerfd_gettime(fd, &timer_spec) == -1);
-}
-#endif
 
 void test_timeout_tick_destroy(void)
 {
+    int ret;
+    int tries;
     struct mk_event_loop *evl;
-    struct mk_event *ev;
+    struct mk_event *fired;
+    struct mk_event ev = {0};
+    uint64_t tick = 0;
     int fd;
     int timeout_interval = 1;
 
-    evl = mk_event_loop_create(1);
-    ev = mk_mem_alloc_z(sizeof(struct mk_event*));
-    fd = mk_event_timeout_create(evl, timeout_interval, 0, ev);
-    TEST_ASSERT(ev->fd == fd);
+    TEST_CHECK(mk_event_init() == 0);
 
-    consume_timer_tick(ev->fd);
-    mk_event_timeout_destroy(evl, ev);
+    evl = mk_event_loop_create(4);
+    TEST_ASSERT(evl != NULL);
 
-    check_timer_invalidated(fd);
+    fd = mk_event_timeout_create(evl, timeout_interval, 0, &ev);
+    TEST_ASSERT(fd >= 0);
+    TEST_ASSERT(ev.fd == fd);
+
+    ret = 0;
+    for (tries = 0; tries < 2 && ret == 0; tries++) {
+        ret = mk_event_wait_2(evl, 1500);
+    }
+    TEST_ASSERT(ret == 1);
+
+    fired = NULL;
+    mk_event_foreach(fired, evl) {
+        TEST_ASSERT(fired == &ev);
+        TEST_ASSERT((fired->mask & MK_EVENT_READ) != 0);
+        break;
+    }
+
+    ret = consume_timer_tick(ev.fd, &tick);
+    TEST_ASSERT(ret == sizeof(tick));
+    TEST_ASSERT(tick == 1);
+
+    ret = mk_event_timeout_destroy(evl, &ev);
+    TEST_ASSERT(ret == 0);
+
+    mk_event_loop_destroy(evl);
 }
 
 TEST_LIST = {

--- a/test/win32_socketpair.c
+++ b/test/win32_socketpair.c
@@ -1,0 +1,49 @@
+/*  Monkey HTTP Server
+ *  ==================
+ *  Copyright 2001-2026 Monkey Software LLC <eduardo@monkey.io>
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <stdint.h>
+#include <winsock2.h>
+
+#include <mk_core/mk_win32_socketpair.h>
+
+#include "mk_tests.h"
+
+void test_win32_socketpair_stream(void)
+{
+    int ret;
+    uint64_t in = 0x12345678;
+    uint64_t out = 0;
+    SOCKET pair[2];
+
+    ret = mk_win32_socketpair(pair);
+    TEST_ASSERT(ret == 0);
+
+    ret = send(pair[0], (const char *) &in, sizeof(in), 0);
+    TEST_ASSERT(ret == sizeof(in));
+
+    ret = recv(pair[1], (char *) &out, sizeof(out), MSG_WAITALL);
+    TEST_ASSERT(ret == sizeof(out));
+    TEST_ASSERT(out == in);
+
+    closesocket(pair[0]);
+    closesocket(pair[1]);
+}
+
+TEST_LIST = {
+    {"win32_socketpair_stream", test_win32_socketpair_stream},
+    {NULL, NULL}
+};


### PR DESCRIPTION
If AF_UNIX with stream is available, we can use it. And if it's not available, we use AT_INET as a fallback.