### PR TITLE
build: fix MinGW-w64 cross-compilation for Windows

### DIFF
--- a/.github/workflows/build-pr.yaml
+++ b/.github/workflows/build-pr.yaml
@@ -42,6 +42,29 @@ jobs:
           cmake -DMK_DEBUG=On -DMK_WITHOUT_BIN=On -DMK_WITHOUT_CONF=On -DMK_LIB_ONLY=On ${{ matrix.config.cmake_additional_opt }} ..\
           cmake --build . --config Release
 
+  build-windows-mingw:
+    name: Cross-build for Windows with MinGW-w64 (UCRT64)
+    runs-on: ubuntu-latest
+    container: fedora:44
+    steps:
+      - name: Install the MinGW-w64 UCRT toolchain and build tools
+        run: >-
+          dnf install -y cmake gcc gcc-c++ git make ninja-build
+          ucrt64-gcc ucrt64-gcc-c++ ucrt64-openssl ucrt64-zlib
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Cross-build monkey as a static library
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          mkdir build
+          cd build
+          cmake -G Ninja \
+            -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
+            -DCMAKE_TOOLCHAIN_FILE=/usr/share/mingw/toolchain-ucrt64.cmake \
+            -DMK_DEBUG=On -DMK_WITHOUT_BIN=On -DMK_WITHOUT_CONF=On -DMK_LIB_ONLY=On \
+            ..
+          cmake --build .
+
   build-unix:
     name: Build sources on amd64 for ${{ matrix.os }} - ${{ matrix.compiler }}
     runs-on: ${{ matrix.os }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,14 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99 -Wall -Wextra")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D__FILENAME__='\"$$(subst ${CMAKE_SOURCE_DIR}/,,$$(abspath \$$<))\"'")
 else()
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D__FILENAME__=__FILE__")
+if(MINGW)
+  # MinGW-w64 only declares the POSIX *_r time functions (localtime_r, ...)
+  # when this feature-test macro is set. The Winsock recv/send/getsockopt
+  # buffer arguments are char* where POSIX is void*, which GCC 14+ makes a
+  # hard error; MSVC accepts them, so keep them warnings under MinGW too.
+  add_definitions(-D_POSIX_THREAD_SAFE_FUNCTIONS=200112L)
+  add_compile_options(-Wno-error=incompatible-pointer-types)
+endif()
 endif()
 
 # Monkey Version

--- a/deps/flb_libco/libco.c
+++ b/deps/flb_libco/libco.c
@@ -8,7 +8,17 @@
 #endif
 
 #if defined(__clang__) || defined(__GNUC__)
-  #if defined(__i386__)
+  #if defined(_WIN32)
+    /*
+     * Check Windows before the architecture: on x86_64 MinGW both __amd64__
+     * and _WIN32 are defined, so amd64.c would win, but its co_swap executes
+     * a machine-code blob held in a read-only array and faults under DEP on
+     * the first coroutine switch (the same reason the MSVC branch below
+     * disables amd64.c "due to SIGSEGV bug"). Use the fiber backend, which is
+     * what MSVC already selects on Windows.
+     */
+    #include "fiber.c"
+  #elif defined(__i386__)
     #include "x86.c"
   #elif defined(__amd64__)
     #include "amd64.c"
@@ -18,8 +28,6 @@
     #include "aarch64.c"
   #elif defined(_ARCH_PPC)
     #include "ppc.c"
-  #elif defined(_WIN32)
-    #include "fiber.c"
   #else
     #include "sjlj.c"
   #endif

--- a/include/monkey/mk_config.h
+++ b/include/monkey/mk_config.h
@@ -27,7 +27,9 @@
 #include "../../deps/rbtree/rbtree.h"
 
 #ifdef _WIN32
+#ifndef __MINGW32__
 typedef uint32_t mode_t;
+#endif
 typedef uint32_t uid_t;
 typedef uint32_t gid_t;
 #endif

--- a/include/monkey/mk_core/external/winuio.h
+++ b/include/monkey/mk_core/external/winuio.h
@@ -8,7 +8,7 @@
 #else
 #include <errno.h>
 #include <io.h>
-#include <BaseTsd.h>
+#include <basetsd.h>
 #include <winsock2.h>
 #include <ws2tcpip.h>
 typedef SSIZE_T ssize_t;

--- a/include/monkey/mk_core/mk_dep_unistd.h
+++ b/include/monkey/mk_core/mk_dep_unistd.h
@@ -44,7 +44,7 @@
 #define STDOUT_FILENO 1
 #define STDERR_FILENO 2
 /* should be in some equivalent to <sys/types.h> */
-#if _MSC_VER >= 1600   /* MSVC 2010 or higher */
+#if defined(__MINGW32__) || _MSC_VER >= 1600   /* MSVC 2010 or higher */
 #include <stdint.h>
 #else
 typedef __int8            int8_t;

--- a/include/monkey/mk_core/mk_list.h
+++ b/include/monkey/mk_core/mk_list.h
@@ -24,8 +24,8 @@
 #include <stddef.h>
 #include "mk_macros.h"
 
-#ifdef _WIN32
-/* Windows */
+#if defined(_WIN32) && !defined(__MINGW32__)
+/* Windows (MSVC): PCHAR/ULONG_PTR come from the Windows SDK headers */
 #define container_of(address, type, field) ((type *)(                   \
                                                      (PCHAR)(address) - \
                                                      (ULONG_PTR)(&((type *)0)->field)))

--- a/include/monkey/mk_core/mk_macros.h
+++ b/include/monkey/mk_core/mk_macros.h
@@ -166,7 +166,7 @@
   #define MK_EXPORT __declspec(dllexport)
 #endif
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(__MINGW32__)
     #define MK_INLINE __forceinline
 #else
     #define MK_INLINE inline __attribute__((always_inline))

--- a/include/monkey/mk_core/mk_sleep.h
+++ b/include/monkey/mk_core/mk_sleep.h
@@ -34,6 +34,7 @@
 #include <windows.h>	/* WinAPI */
 
 /* Windows sleep in 100ns units */
+#ifndef __MINGW32__
 static inline BOOLEAN nanosleep(LONGLONG ns){
 	/* Declarations */
 	HANDLE timer;	/* Timer handle */
@@ -54,6 +55,7 @@ static inline BOOLEAN nanosleep(LONGLONG ns){
 	/* Slept without problems */
 	return TRUE;
 }
+#endif
 #endif
 
 #endif

--- a/include/monkey/mk_scheduler.h
+++ b/include/monkey/mk_scheduler.h
@@ -38,10 +38,12 @@
 #define MK_SCHED_SIGNAL_EVENT_LOOP_BREAK 0xEEFFAACC
 
 #ifdef _WIN32
+#ifndef __MINGW32__
     /* The pid field in the mk_sched_worker structure is ignored in platforms other than
      * linux and mac os so it can be safely plugged in this meaningless way
      */
     typedef uint64_t pid_t;
+#endif
 #endif
 
 /*

--- a/include/monkey/mk_thread_libco.h
+++ b/include/monkey/mk_thread_libco.h
@@ -26,6 +26,18 @@
 
 #include <limits.h>
 
+/*
+ * MinGW-w64's winpthreads, unlike glibc, does not define PTHREAD_STACK_MIN.
+ * MinGW uses the POSIX threading model (the real <pthread.h>), so provide it
+ * here or MK_THREAD_STACK_SIZE below will not compile; 16384 is the glibc
+ * x86-64 minimum, matching the value the other POSIX platforms build with.
+ * MSVC is unaffected: its winpthreads shim (pulled in via mk_pthread.h before
+ * this header) already defines PTHREAD_STACK_MIN, so this guard is a no-op.
+ */
+#ifndef PTHREAD_STACK_MIN
+#define PTHREAD_STACK_MIN 16384
+#endif
+
 #ifdef MK_HAVE_VALGRIND
 #include <valgrind/valgrind.h>
 #endif

--- a/mk_core/CMakeLists.txt
+++ b/mk_core/CMakeLists.txt
@@ -20,11 +20,17 @@ endmacro()
 
 # Set threading system
 if (CMAKE_SYSTEM_NAME MATCHES "Windows")
-  MK_DEFINITION(MK_THREADS_WIN32)
-  set(src
-    ${src}
-    "external/winpthreads.c"
-    )
+  if (MSVC)
+    MK_DEFINITION(MK_THREADS_WIN32)
+    set(src
+      ${src}
+      "external/winpthreads.c"
+      )
+  else()
+    # MinGW-w64 ships a real pthread implementation (winpthreads), so the
+    # POSIX threading model applies; the hand-rolled shim is MSVC-only.
+    MK_DEFINITION(MK_THREADS_POSIX)
+  endif()
   add_subdirectory(deps/)
 else()
   if (MK_EVENT_LOOP_LIBEVENT)

--- a/mk_core/deps/libevent/CMakeLists.txt
+++ b/mk_core/deps/libevent/CMakeLists.txt
@@ -435,7 +435,7 @@ CHECK_TYPE_SIZE("off_t" EVENT__SIZEOF_OFF_T LANGUAGE C)
 
 # Winssck.
 if (_MSC_VER)
-    list(APPEND CMAKE_EXTRA_INCLUDE_FILES BaseTsd.h)
+    list(APPEND CMAKE_EXTRA_INCLUDE_FILES basetsd.h)
 endif()
 CHECK_TYPE_SIZE("ssize_t" EVENT__SIZEOF_SSIZE_T_LOWER LANGUAGE C)
 CHECK_TYPE_SIZE("SSIZE_T" EVENT__SIZEOF_SSIZE_T_UPPER LANGUAGE C)
@@ -786,6 +786,13 @@ else (EVENT__BUILD_SHARED_LIBRARIES)
   set(EVENT__LIBRARY_TYPE STATIC)
 endif (EVENT__BUILD_SHARED_LIBRARIES)
 
+if(MINGW)
+  # MinGW-w64 declares strtok_r in <string.h>, but libevent's WIN32 function
+  # check (CheckFunctionExistsEx.c takes the function's address) only sees the
+  # force-included winsock headers, so it mis-detects strtok_r as absent and
+  # then defines a conflicting static strtok_r in evdns.c. Set it explicitly.
+  set(EVENT__HAVE_STRTOK_R 1)
+endif()
 configure_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/event-config.h.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/include/event2/event-config.h
@@ -822,6 +829,14 @@ add_library(event ${EVENT__LIBRARY_TYPE}
     ${HDR_PUBLIC}
     ${SRC_CORE}
     ${SRC_EXTRA})
+
+if(WIN32)
+    # Record the winsock dependency on the static archives too, so
+    # consumers order -lws2_32 after them (GNU ld resolves left to right).
+    target_link_libraries(event_core ${LIB_PLATFORM})
+    target_link_libraries(event_extra ${LIB_PLATFORM})
+    target_link_libraries(event ${LIB_PLATFORM})
+endif()
 
 if (EVENT__BUILD_SHARED_LIBRARIES)
     # Prepare static library to be linked to tests that need hidden symbols

--- a/mk_core/deps/libevent/evutil.c
+++ b/mk_core/deps/libevent/evutil.c
@@ -39,6 +39,13 @@
 #undef _WIN32_WINNT
 /* For structs needed by GetAdaptersAddresses */
 #define _WIN32_WINNT 0x0501
+#ifdef __MINGW32__
+/* MinGW-w64's sdkddkver.h rejects a _WIN32_WINNT that disagrees with
+ * NTDDI_VERSION; pin NTDDI to the same level. MSVC does not enforce this
+ * and is left unchanged. */
+#undef NTDDI_VERSION
+#define NTDDI_VERSION 0x05010000
+#endif
 #include <iphlpapi.h>
 #endif
 

--- a/mk_core/mk_rconf.c
+++ b/mk_core/mk_rconf.c
@@ -23,7 +23,7 @@
 #include <string.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#ifndef _MSC_VER
+#ifndef _WIN32
 #include <glob.h>
 #endif
 
@@ -33,7 +33,7 @@
 #include <mk_core/mk_list.h>
 
 #ifdef _WIN32
-#include <Windows.h>
+#include <windows.h>
 #include <strsafe.h>
 #define PATH_MAX MAX_PATH
 #endif
@@ -604,7 +604,7 @@ static int mk_rconf_path_set(struct mk_rconf *conf, char *file)
     char *end;
     char path[PATH_MAX + 1];
 
-#ifdef _MSC_VER
+#ifdef _WIN32
     p = _fullpath(path, file, PATH_MAX + 1);
 #else
     p = realpath(file, path);

--- a/mk_core/mk_utils.c
+++ b/mk_core/mk_utils.c
@@ -37,6 +37,7 @@
 #elif defined (_WIN32)
 #include <winsock2.h>
 
+#ifndef __MINGW32__
 #ifndef localtime_r
     struct tm *localtime_r(time_t *_clock, struct tm *_result)
     {
@@ -70,6 +71,7 @@
 
         return 0;
     }
+#endif /* !__MINGW32__ */
 
 #endif
 


### PR DESCRIPTION
This lets monkey build for a Windows target with the MinGW-w64 UCRT toolchain (GCC), in addition to MSVC. Everything MinGW-specific is gated on `MINGW`/`__MINGW32__` (or falls under existing `!__MINGW32__` guards), so MSVC builds compile the same code as before.

**Build fixes** (`build: fix MinGW-w64 cross-compilation for Windows`):

- Set `_POSIX_THREAD_SAFE_FUNCTIONS` so MinGW declares the POSIX `*_r` time functions (`localtime_r`, ...), and keep the incompatible-pointer-type mismatches (Winsock `recv`/`send`/`getsockopt` take `char*` buffers where POSIX uses `void*`) as warnings — GCC 14+ otherwise rejects them as errors, while MSVC accepts both.
- Select the POSIX threading model on MinGW, which ships a real pthread implementation (winpthreads); the hand-rolled Windows pthread shim stays MSVC-only.
- Guard the MSVC-only typedefs and shims (`mode_t`, `pid_t`, `timespec`, the `nanosleep`/`localtime_r` replacements, the stdint fallback) that the MinGW headers already provide.
- Widen MSVC-only gates that cover Windows functionality (the `glob` fallback, `_fullpath`, `MK_INLINE`) to `_WIN32`.
- Use the standard GCC `container_of` on MinGW; the `PCHAR`/`ULONG_PTR` variant relies on Windows SDK typedefs only MSVC pulls in implicitly.
- Lowercase capitalized Windows header includes so they resolve on a case-sensitive filesystem when cross-compiling from Linux.
- In the bundled flb_libco, check `_WIN32` before the architecture so x86_64 MinGW selects the fiber backend instead of `amd64.c` (whose `co_swap` runs a read-only machine-code blob that faults under DEP on the first coroutine switch), matching the MSVC branch that already disables `amd64.c`. This same fix is submitted upstream to flb_libco as edsiper/flb_libco#12 — monkey's vendored copy can drop it once that merges and flb_libco is re-synced.
- For the bundled libevent: record the winsock dependency on the static archives; and, for MinGW only, pin `NTDDI_VERSION` next to the existing `_WIN32_WINNT` override in `evutil.c` (its `sdkddkver.h` errors when the two disagree, where MSVC does not, so MSVC compiles the file unchanged) and define `EVENT__HAVE_STRTOK_R` (libevent's WIN32 function check takes the function's address and only sees the force-included winsock headers, so it mis-detects `strtok_r` from `<string.h>` and then defines a conflicting static copy).

**CI** (`workflows: add a MinGW-w64 cross-compile check`): a new `build-windows-mingw` job cross-builds monkey as a library from Linux with the Fedora MinGW-w64 UCRT64 toolchain, alongside the existing MSVC Windows job, so the MinGW support doesn't regress. It uses the same library-only profile (`MK_LIB_ONLY`, no bin/conf) as the MSVC job.

### Testing

- Cross-compiled monkey as a static library with the Fedora MinGW-w64 UCRT64 toolchain (the exact command the new CI job runs) — builds cleanly, `libmonkey.a` produced, 0 errors.
- Verified in context by cross-compiling Fluent Bit (which vendors monkey) for Windows from Linux with the same toolchain — monkey compiles and links into a working `fluent-bit.exe` (PE32+ x86-64).
- The MSVC path is unchanged: the MinGW-specific defines/gates are scoped to `MINGW`/`__MINGW32__`, and `evutil.c` compiles byte-for-byte as before under MSVC.

