### PR TITLE
server: parser: accept empty header values

### DIFF
--- a/integration_tests/tests/test_network_layer.py
+++ b/integration_tests/tests/test_network_layer.py
@@ -424,6 +424,38 @@ def test_empty_generic_header_values_are_accepted(monkey_instance: MonkeyManager
     assert b"HTTP/1.1 200 OK" in response
 
 
+def test_empty_connection_and_transfer_encoding_are_accepted(
+    monkey_instance: MonkeyManager,
+):
+    response = monkey_instance.raw_request(
+        b"GET / HTTP/1.1\r\n"
+        b"Host: localhost\r\n"
+        b"Connection:\r\n"
+        b"Transfer-Encoding: \t\r\n"
+        b"Connection: close\r\n"
+        b"\r\n"
+    )
+
+    assert b"HTTP/1.1 200 OK" in response
+
+
+def test_fragmented_empty_header_value_is_accepted(monkey_instance: MonkeyManager):
+    response = monkey_instance.raw_request_parts(
+        [
+            b"GET / HTTP/1.1\r\n"
+            b"Host: localhost\r\n"
+            b"X-Empty:",
+            b"\r",
+            b"\n"
+            b"Connection: close\r\n"
+            b"\r\n",
+        ],
+        pause_between_parts=0.01,
+    )
+
+    assert b"HTTP/1.1 200 OK" in response
+
+
 def test_empty_host_header_returns_400(monkey_instance: MonkeyManager):
     response = monkey_instance.raw_request(
         b"GET / HTTP/1.1\r\n"

--- a/integration_tests/tests/test_network_layer.py
+++ b/integration_tests/tests/test_network_layer.py
@@ -411,6 +411,42 @@ def test_http10_without_host_is_accepted(monkey_instance: MonkeyManager):
     assert b"HTTP/1.1 200 OK" in response
 
 
+def test_empty_generic_header_values_are_accepted(monkey_instance: MonkeyManager):
+    response = monkey_instance.raw_request(
+        b"GET / HTTP/1.1\r\n"
+        b"Host: localhost\r\n"
+        b"X-Empty:\r\n"
+        b"X-Empty-Whitespace: \t\r\n"
+        b"Connection: close\r\n"
+        b"\r\n"
+    )
+
+    assert b"HTTP/1.1 200 OK" in response
+
+
+def test_empty_host_header_returns_400(monkey_instance: MonkeyManager):
+    response = monkey_instance.raw_request(
+        b"GET / HTTP/1.1\r\n"
+        b"Host:\r\n"
+        b"Connection: close\r\n"
+        b"\r\n"
+    )
+
+    assert b"HTTP/1.1 400" in response
+
+
+def test_empty_upgrade_header_returns_400(monkey_instance: MonkeyManager):
+    response = monkey_instance.raw_request(
+        b"GET / HTTP/1.1\r\n"
+        b"Host: localhost\r\n"
+        b"Upgrade:\r\n"
+        b"Connection: close\r\n"
+        b"\r\n"
+    )
+
+    assert b"HTTP/1.1 400" in response
+
+
 def test_absolute_form_request_target_returns_400(monkey_instance: MonkeyManager):
     response = monkey_instance.raw_request(
         b"GET http://localhost/ HTTP/1.1\r\n"

--- a/integration_tests/tests/test_network_layer.py
+++ b/integration_tests/tests/test_network_layer.py
@@ -424,6 +424,102 @@ def test_empty_generic_header_values_are_accepted(monkey_instance: MonkeyManager
     assert b"HTTP/1.1 200 OK" in response
 
 
+def test_post_with_body_and_empty_generic_header_is_accepted(
+    monkey_instance: MonkeyManager,
+):
+    response = monkey_instance.raw_request(
+        b"POST / HTTP/1.1\r\n"
+        b"Host: localhost\r\n"
+        b"Content-Type: application/json\r\n"
+        b"Content-Length: 2\r\n"
+        b"X-Empty:\r\n"
+        b"Connection: close\r\n"
+        b"\r\n"
+        b"{}"
+    )
+
+    assert b"HTTP/1.1 200 OK" in response
+
+
+@pytest.mark.parametrize("header_value", [b"", b" \t"])
+def test_empty_content_length_before_numeric_header_returns_400(
+    monkey_instance: MonkeyManager,
+    header_value: bytes,
+):
+    response = monkey_instance.raw_request(
+        b"POST / HTTP/1.1\r\n"
+        b"Host: localhost\r\n"
+        b"Content-Length:" + header_value + b"\r\n"
+        b"1-X: value\r\n"
+        b"Connection: close\r\n"
+        b"\r\n"
+        b"1"
+    )
+
+    assert b"HTTP/1.1 400" in response
+
+
+@pytest.mark.parametrize("header_value", [b"", b" \t"])
+def test_empty_content_length_before_numeric_body_returns_400(
+    monkey_instance: MonkeyManager,
+    header_value: bytes,
+):
+    response = monkey_instance.raw_request(
+        b"POST / HTTP/1.1\r\n"
+        b"Host: localhost\r\n"
+        b"Connection: close\r\n"
+        b"Content-Length:" + header_value + b"\r\n"
+        b"\r\n"
+        b"1"
+    )
+
+    assert b"HTTP/1.1 400" in response
+
+
+@pytest.mark.parametrize("header_value", [b"2x", b"2 1", b"+2", b"-1"])
+def test_invalid_content_length_value_returns_400(
+    monkey_instance: MonkeyManager,
+    header_value: bytes,
+):
+    response = monkey_instance.raw_request(
+        b"POST / HTTP/1.1\r\n"
+        b"Host: localhost\r\n"
+        b"Content-Length: " + header_value + b"\r\n"
+        b"Connection: close\r\n"
+        b"\r\n"
+        b"{}"
+    )
+
+    assert b"HTTP/1.1 400" in response
+
+
+def test_content_length_overflow_returns_413(monkey_instance: MonkeyManager):
+    response = monkey_instance.raw_request(
+        b"POST / HTTP/1.1\r\n"
+        b"Host: localhost\r\n"
+        b"Content-Length: 9999999999999999999999999999999999999999\r\n"
+        b"Connection: close\r\n"
+        b"\r\n"
+    )
+
+    assert b"HTTP/1.1 413" in response
+
+
+def test_content_length_with_trailing_whitespace_is_accepted(
+    monkey_instance: MonkeyManager,
+):
+    response = monkey_instance.raw_request(
+        b"POST / HTTP/1.1\r\n"
+        b"Host: localhost\r\n"
+        b"Content-Length: 2 \t\r\n"
+        b"Connection: close\r\n"
+        b"\r\n"
+        b"{}"
+    )
+
+    assert b"HTTP/1.1 200 OK" in response
+
+
 def test_empty_connection_and_transfer_encoding_are_accepted(
     monkey_instance: MonkeyManager,
 ):

--- a/mk_server/mk_http_parser.c
+++ b/mk_server/mk_http_parser.c
@@ -205,11 +205,55 @@ static inline int header_cmp(const char *expected, char *value, int len)
     return 0;
 }
 
+static inline int content_length_parse(char *value, unsigned long len,
+                                       long *result)
+{
+    int digit;
+    long parsed;
+    unsigned long i;
+
+    if (len == 0) {
+        return -MK_CLIENT_BAD_REQUEST;
+    }
+
+    parsed = 0;
+    for (i = 0; i < len; i++) {
+        if (value[i] == ' ' || value[i] == '\t') {
+            break;
+        }
+
+        if (value[i] < '0' || value[i] > '9') {
+            return -MK_CLIENT_BAD_REQUEST;
+        }
+
+        digit = value[i] - '0';
+        if (parsed > (LONG_MAX - digit) / 10) {
+            return -MK_CLIENT_REQUEST_ENTITY_TOO_LARGE;
+        }
+
+        parsed = (parsed * 10) + digit;
+    }
+
+    if (i == 0) {
+        return -MK_CLIENT_BAD_REQUEST;
+    }
+
+    for (; i < len; i++) {
+        if (value[i] != ' ' && value[i] != '\t') {
+            return -MK_CLIENT_BAD_REQUEST;
+        }
+    }
+
+    *result = parsed;
+    return 0;
+}
+
 static inline int header_lookup(struct mk_http_parser *p, char *buffer)
 {
     int i;
     int len;
     int pos;
+    int ret;
     long val;
     char *endptr;
     char *tmp;
@@ -279,17 +323,14 @@ static inline int header_lookup(struct mk_http_parser *p, char *buffer)
                 }
             }
             else if (i == MK_HEADER_CONTENT_LENGTH) {
-                errno = 0;
-                val = strtol(header->val.data, &endptr, 10);
-                if ((errno == ERANGE && (val == LONG_MAX || val == LONG_MIN))
-                    || (errno != 0 && val == 0)) {
-                    return -MK_CLIENT_REQUEST_ENTITY_TOO_LARGE;
+                if (header->val.len == 0) {
+                    return -MK_CLIENT_BAD_REQUEST;
                 }
-                if (endptr == header->val.data) {
-                    return -1;
-                }
-                if (val < 0) {
-                    return -1;
+
+                ret = content_length_parse(header->val.data,
+                                           header->val.len, &val);
+                if (ret != 0) {
+                    return ret;
                 }
 
                 p->header_content_length = val;

--- a/mk_server/mk_http_parser.c
+++ b/mk_server/mk_http_parser.c
@@ -243,6 +243,10 @@ static inline int header_lookup(struct mk_http_parser *p, char *buffer)
             mk_list_add(&header->_head, &p->header_list);
 
             if (i == MK_HEADER_HOST) {
+                if (header->val.len == 0) {
+                    return -MK_CLIENT_BAD_REQUEST;
+                }
+
                 /* Handle a possible port number in the Host header */
                 int sep = str_searchr(header->val.data, ':', header->val.len);
                 if (sep > 0) {
@@ -291,6 +295,11 @@ static inline int header_lookup(struct mk_http_parser *p, char *buffer)
                 p->header_content_length = val;
             }
             else if (i == MK_HEADER_CONNECTION) {
+                if (header->val.len == 0) {
+                    p->header_connection = MK_HTTP_PARSER_CONN_UNKNOWN;
+                    return 0;
+                }
+
                 /* Check Connection: Keep-Alive */
                 if (header->val.len == sizeof(MK_CONN_KEEP_ALIVE) - 1) {
                     if (header_cmp(MK_CONN_KEEP_ALIVE,
@@ -331,6 +340,10 @@ static inline int header_lookup(struct mk_http_parser *p, char *buffer)
                 }
             }
             else if (i == MK_HEADER_TRANSFER_ENCODING) {
+                if (header->val.len == 0) {
+                    return 0;
+                }
+
                 /* Check Transfer-Encoding: chunked */
                 pos = mk_string_search_n(header->val.data,
                                          "chunked",
@@ -377,6 +390,10 @@ static inline int header_lookup(struct mk_http_parser *p, char *buffer)
                 }
             }
             else if (i == MK_HEADER_UPGRADE) {
+                    if (header->val.len == 0) {
+                        return -MK_CLIENT_BAD_REQUEST;
+                    }
+
                     if (header_cmp(MK_UPGRADE_H2C,
                                    header->val.data, header->val.len) == 0) {
                         p->header_upgrade = MK_HTTP_PARSER_UPGRADE_H2C;
@@ -1008,11 +1025,36 @@ int mk_http_parser(struct mk_http_request *req, struct mk_http_parser *p,
             }
             /* Parsing the header value */
             else if (p->status == MK_ST_HEADER_VALUE) {
-                /* Trim left, set starts only when found something != ' ' */
-                if (buffer[p->i] == '\r' || buffer[p->i] == '\n') {
+                /* Empty field values are valid; trim optional whitespace. */
+                if (buffer[p->i] == '\r') {
+                    p->header_val = p->i;
+                    mark_end();
+
+                    ret = header_lookup(p, buffer);
+                    if (ret != 0) {
+                        if (ret < -1) {
+                            mk_http_error(-ret, req->session, req, server);
+                        }
+                        return MK_HTTP_PARSER_ERROR;
+                    }
+
+                    /* Try to catch next LF */
+                    if (p->i + 1 < len) {
+                        if (buffer[p->i + 1] == '\n') {
+                            p->i++;
+                            p->status = MK_ST_HEADER_KEY;
+                            p->chars = -1;
+                            start_next();
+                        }
+                    }
+
+                    p->status = MK_ST_HEADER_END;
+                    start_next();
+                }
+                else if (buffer[p->i] == '\n') {
                     return MK_HTTP_PARSER_ERROR;
                 }
-                else if (buffer[p->i] != ' ') {
+                else if (buffer[p->i] != ' ' && buffer[p->i] != '\t') {
                     p->status = MK_ST_HEADER_VAL_STARTS;
                     p->start = p->header_val = p->i;
                 }


### PR DESCRIPTION
## Summary

Monkey rejects generic HTTP field values when no non-whitespace octet appears
after the colon. Empty generic field values are valid according to RFC 9110
section 5.5, so otherwise valid requests fail parsing.

Accept empty and optional-whitespace-only generic values and trim both SP and
HTAB before non-empty values. Preserve stricter validation for empty `Host`
and `Upgrade` fields, and avoid unbounded searches for empty `Connection` and
`Transfer-Encoding` values.

Add raw HTTP integration coverage for accepted generic and control fields,
rejected empty semantic fields, and an empty value fragmented across the
colon/CR/LF parsing boundaries.

## Testing

- `cmake -S . -B build -DMK_TESTS=On -DMK_TLS=On -DMK_TLS_BACKEND=openssl`
- `cmake --build build -j8`
- `build/bin/mk-test-lib_server`
- `build/bin/mk-test-event_timeout`
- `integration_tests/.venv/bin/python integration_tests/run_tests.py --plain-binary build/bin/monkey --binaries plain --quiet integration_tests/tests/test_network_layer.py -k "empty_generic or empty_connection or fragmented_empty or empty_host or empty_upgrade"` (5 passed)
- `integration_tests/.venv/bin/python integration_tests/run_tests.py --plain-binary build/bin/monkey --binaries plain --quiet integration_tests/tests/test_network_layer.py` (26 passed)
- The same focused and full integration commands against an AddressSanitizer build with `ASAN_OPTIONS=detect_leaks=0:halt_on_error=1:abort_on_error=1` (5 and 26 passed)
- Clean Ubuntu 24.04 Docker run with GCC 13.3 and OpenSSL, a read-only host mount, and a disposable internal source copy: build passed, both native tests passed, focused integration 5 passed, and full integration 26 passed

## Context

Related to fluent/fluent-bit#12174. Requested during review of
fluent/fluent-bit#12175.

RFC 9110 section 5.5:
https://www.rfc-editor.org/rfc/rfc9110.html#section-5.5